### PR TITLE
feat: Add initial UI for Book Cipher tab

### DIFF
--- a/index.html
+++ b/index.html
@@ -159,8 +159,47 @@
     </div>
         </div>
         <div id="book-cipher-tab" class="tab-content hidden">
-            <!-- Placeholder for Book Cipher content -->
-            <p class="text-center text-xl p-8">Book Cipher Content Coming Soon!</p>
+            <div class="app-container mx-auto p-6 bg-gray-800 shadow-xl rounded-lg">
+                <!-- Book Selection Dropdown -->
+                <div class="mb-4">
+                    <label for="book-selection" class="block mb-2 text-sm font-medium text-gray-300">Select Book:</label>
+                    <select id="book-selection" class="bg-gray-700 border border-gray-600 text-white text-sm rounded-lg focus:ring-blue-500 focus:border-blue-500 block w-full p-2.5">
+                        <option selected>Choose a book</option>
+                        <option value="wildwood">The Call of the Wildwood</option>
+                        <option value="morse_mysteries">Morse Mysteries Vol. 1</option>
+                        <option value="code_star">Journey to the Code Star</option>
+                    </select>
+                </div>
+
+                <!-- Obscured/Target Text Display -->
+                <div class="mb-4">
+                    <label for="target-text-display" class="block mb-2 text-sm font-medium text-gray-300">Target Text:</label>
+                    <div id="target-text-display" class="p-3 min-h-[100px] bg-gray-700 border border-gray-600 rounded-md text-gray-300 whitespace-pre-wrap word-wrap-break-word">**** *** ****</div>
+                </div>
+
+                <!-- Unlocked Text Display -->
+                <div class="mb-4">
+                    <label for="unlocked-text-display" class="block mb-2 text-sm font-medium text-gray-300">Your Unlocked Text:</label>
+                    <div id="unlocked-text-display" class="p-3 min-h-[100px] bg-gray-700 border border-gray-600 rounded-md text-gray-300 whitespace-pre-wrap word-wrap-break-word">-</div>
+                </div>
+
+                <!-- Current Decoded Character Display -->
+                <div class="mb-4 text-center">
+                    <label for="current-decoded-char" class="block mb-2 text-sm font-medium text-gray-300">Current Character:</label>
+                    <div id="current-decoded-char" class="p-2 bg-gray-700 rounded-md text-xl font-mono text-center min-w-[50px] inline-block text-gray-300">-</div>
+                </div>
+                
+                <!-- Morse Input/Output Area -->
+                <div class="mb-6">
+                    <label for="book-cipher-morse-io" class="block text-sm font-medium text-gray-300 mb-1">Morse Input/Output:</label>
+                    <textarea id="book-cipher-morse-io" class="input-output-box w-full" placeholder="Morse input/output for book cipher..."></textarea>
+                </div>
+
+                <!-- Start Button -->
+                <div class="text-center">
+                    <button id="start-book-btn" class="px-6 py-2 bg-blue-600 hover:bg-blue-700 text-white font-semibold rounded-lg shadow-md focus:outline-none focus:ring-2 focus:ring-blue-400 focus:ring-opacity-75">Start Selected Book</button>
+                </div>
+            </div>
         </div>
         <div id="morse-pals-tab" class="tab-content hidden">
             <!-- Placeholder for Morse Pals content -->


### PR DESCRIPTION
Adds the basic HTML structure and Tailwind CSS styling for the "Book Cipher" tab.

This includes:
- A book selection dropdown.
- Display areas for obscured/target text and unlocked text.
- A display for the current decoded character.
- A "Start Selected Book" button.
- A textarea for Morse input/output within the tab.

The new elements are styled to be visually consistent with the existing "Learn & Practice" tab. The JavaScript for tab navigation and other application logic remains unchanged.