### PR TITLE
feat: Implement settings tab UI and logic for tapper speed

### DIFF
--- a/index.html
+++ b/index.html
@@ -245,8 +245,18 @@
             <p class="text-center text-xl p-8">Global Beacon Content Coming Soon!</p>
         </div>
         <div id="settings-tab" class="tab-content hidden">
-            <!-- Placeholder for Settings content -->
-            <p class="text-center text-xl p-8">Settings Content Coming Soon!</p>
+            <div class="app-container">
+                <h2 class="section-title text-2xl font-semibold mb-3 text-center">Tapper Speed Settings</h2>
+                <div class="grid grid-cols-1 md:grid-cols-2 gap-4 items-center justify-items-center p-4">
+                    <div class="w-full">
+                        <label for="unit-time-input" class="block text-sm font-medium mb-1">Morse Unit Time (ms):</label>
+                        <input type="number" id="unit-time-input" value="150" min="50" max="500" step="10" class="mt-1 block w-full px-3 py-2 bg-gray-700 border border-gray-600 rounded-md text-sm shadow-sm placeholder-gray-400 focus:outline-none focus:border-indigo-500 focus:ring-1 focus:ring-indigo-500 text-white">
+                    </div>
+                    <div class="mt-4 md:mt-0 w-full text-center md:text-left">
+                        <p class="text-sm font-medium text-gray-300">Current effective value: <span id="current-unit-time-display" class="font-bold text-white">150</span> ms</p>
+                    </div>
+                </div>
+            </div>
         </div>
     </div>
 
@@ -716,6 +726,7 @@ document.addEventListener('DOMContentLoaded', () => {
         // VISUAL TAPPER JS HAS BEEN MOVED FROM HERE
     </script>
     <script src="js/visualTapper.js" defer></script>
-    <script src="js/bookCipher.js" defer></script>
+    <script src="js/settings.js" defer></script> 
+    <script src="js/bookCipher.js" defer></script> 
 </body>
 </html>

--- a/js/settings.js
+++ b/js/settings.js
@@ -1,0 +1,56 @@
+document.addEventListener('DOMContentLoaded', () => {
+    const unitTimeInput = document.getElementById('unit-time-input');
+    const currentUnitTimeDisplay = document.getElementById('current-unit-time-display');
+
+    // Check if the necessary elements are found
+    if (!unitTimeInput || !currentUnitTimeDisplay) {
+        console.error("Settings U.I. elements (unit-time-input or current-unit-time-display) not found. Settings script will not initialize.");
+        return;
+    }
+
+    // Function to update the settings UI elements
+    function updateSettingsUI(value) {
+        if (value === undefined || value === null) {
+            console.warn("updateSettingsUI called with undefined or null value.");
+            return;
+        }
+        const numericValue = parseInt(value);
+        if (isNaN(numericValue)) {
+            console.warn("updateSettingsUI called with a non-numeric value:", value);
+            return;
+        }
+        unitTimeInput.value = numericValue.toString();
+        currentUnitTimeDisplay.textContent = numericValue.toString();
+    }
+
+    // Initialize the UI with the current UNIT_TIME_MS from visualTapper.js
+    // This relies on UNIT_TIME_MS being a global variable (e.g., window.UNIT_TIME_MS or declared with var/let at top scope of visualTapper.js)
+    // and visualTapper.js having executed its localStorage load logic.
+    if (typeof UNIT_TIME_MS !== 'undefined') {
+        updateSettingsUI(UNIT_TIME_MS);
+    } else {
+        console.error("UNIT_TIME_MS is not defined globally. Cannot initialize settings UI. Ensure visualTapper.js is loaded first and defines UNIT_TIME_MS globally.");
+        // Fallback to a default value for the UI if UNIT_TIME_MS is somehow not available
+        // This helps prevent a broken UI state, though underlying functionality might be impaired.
+        updateSettingsUI(150); // Default visual
+    }
+
+    // Event listener for the input field
+    unitTimeInput.addEventListener('input', () => {
+        const newValue = parseInt(unitTimeInput.value);
+        if (isNaN(newValue)) {
+            console.warn("Invalid input for unit time:", unitTimeInput.value);
+            return;
+        }
+
+        // Call the global function from visualTapper.js to update the actual timing
+        if (typeof updateVisualTapperUnitTime === 'function') {
+            updateVisualTapperUnitTime(newValue);
+        } else {
+            console.error("updateVisualTapperUnitTime function is not defined globally. Cannot update tapper speed. Ensure visualTapper.js is loaded first and defines this function globally.");
+        }
+
+        // Update the UI in the settings tab
+        updateSettingsUI(newValue);
+    });
+});

--- a/js/visualTapper.js
+++ b/js/visualTapper.js
@@ -1,3 +1,17 @@
+// Top of js/visualTapper.js
+let UNIT_TIME_MS = 150; 
+let DOT_THRESHOLD_MS = UNIT_TIME_MS * 1.5;
+let LETTER_SPACE_SILENCE_MS = UNIT_TIME_MS * 3;
+
+// Function to update unit time and related variables
+function updateVisualTapperUnitTime(newUnitTime) {
+  UNIT_TIME_MS = parseInt(newUnitTime);
+  DOT_THRESHOLD_MS = UNIT_TIME_MS * 1.5;
+  LETTER_SPACE_SILENCE_MS = UNIT_TIME_MS * 3;
+  localStorage.setItem('visualTapperUnitTime', UNIT_TIME_MS.toString());
+  console.log("Visual Tapper UNIT_TIME_MS updated to:", UNIT_TIME_MS, "Derived DOT_THRESHOLD_MS:", DOT_THRESHOLD_MS, "LETTER_SPACE_SILENCE_MS:", LETTER_SPACE_SILENCE_MS);
+}
+
 document.addEventListener('DOMContentLoaded', () => {
     // --- Visual Tapper JavaScript ---
     const tapper = document.getElementById('tapper');
@@ -22,10 +36,10 @@ document.addEventListener('DOMContentLoaded', () => {
     }
     
     // Define Placeholders & Tapper Variables
-    const UNIT_TIME_MS = 150; // Standard unit time for Morse code element
-    const DOT_THRESHOLD_MS = UNIT_TIME_MS * 1.5; // Max duration for a dot
-    // const SHORT_SPACE_MS = UNIT_TIME_MS * 3; // Silence duration between letters (original constant name)
-    const LETTER_SPACE_SILENCE_MS = UNIT_TIME_MS * 3; // More descriptive for its use here.
+    // const UNIT_TIME_MS = 150; // Standard unit time for Morse code element - MOVED TO GLOBAL
+    // const DOT_THRESHOLD_MS = UNIT_TIME_MS * 1.5; // Max duration for a dot - MOVED TO GLOBAL
+    // const SHORT_SPACE_MS = UNIT_TIME_MS * 3; // Silence duration between letters (original constant name) - MOVED TO GLOBAL
+    // const LETTER_SPACE_SILENCE_MS = UNIT_TIME_MS * 3; // More descriptive for its use here. - MOVED TO GLOBAL
     // const WORD_SPACE_SILENCE_MS = UNIT_TIME_MS * 7; // Silence duration between words (not directly used by this tapper's decodeMorse for sending word spaces)
     const TAP_SOUND_FREQ = 770; // Frequency for tap sound
 
@@ -208,5 +222,17 @@ document.addEventListener('DOMContentLoaded', () => {
     // Initial check for Tone.js (optional, for debugging or early warning)
     if (typeof Tone === 'undefined') {
         console.warn("VisualTapper: Tone.js library not detected. Tap sounds will be unavailable.");
+    }
+
+    const savedUnitTime = localStorage.getItem('visualTapperUnitTime');
+    if (savedUnitTime) {
+        console.log("Found saved unit time in localStorage:", savedUnitTime);
+        updateVisualTapperUnitTime(parseInt(savedUnitTime)); 
+    } else {
+        console.log("No saved unit time in localStorage, ensuring default configuration is applied via updateVisualTapperUnitTime.");
+        // This call ensures that DOT_THRESHOLD_MS and LETTER_SPACE_SILENCE_MS are initialized
+        // through the same function, using the default UNIT_TIME_MS.
+        // It also handles saving the default to localStorage if it wasn't there.
+        updateVisualTapperUnitTime(UNIT_TIME_MS); // UNIT_TIME_MS here is the initial default (e.g., 150)
     }
 });


### PR DESCRIPTION
Adds a "Tapper Speed Settings" section to the "Settings" tab, allowing you to control the visual tapper's `UNIT_TIME_MS`.

Key changes:
- Modified `js/visualTapper.js`:
  - `UNIT_TIME_MS`, `DOT_THRESHOLD_MS`, and `LETTER_SPACE_SILENCE_MS` are now configurable `let` variables.
  - Introduced `updateVisualTapperUnitTime(newUnitTime)` global function to update these values and persist `UNIT_TIME_MS` to localStorage.
  - On load, `UNIT_TIME_MS` is retrieved from localStorage or initialized to a default (150ms), ensuring derived timings are correctly calculated.
- Updated `index.html`:
  - Added UI elements (number input and current value display) to the "Settings" tab for adjusting `UNIT_TIME_MS`.
- Created `js/settings.js`:
  - This new script manages the settings UI.
  - It initializes the UI with the current `UNIT_TIME_MS` from `visualTapper.js`.
  - It listens for input changes, calls `updateVisualTapperUnitTime()`, and updates the displayed current value.
  - Included `js/settings.js` in `index.html` with correct load order.

This feature allows you to customize the Morse code input speed of the visual tapper, and the setting persists across sessions.