### PR TITLE
feat: Add master sound toggle to settings

### DIFF
--- a/index.html
+++ b/index.html
@@ -494,6 +494,17 @@
                         <p class="text-sm font-medium text-gray-300">Current effective value: <span id="current-unit-time-display" class="font-bold text-white">150</span> ms</p>
                     </div>
                 </div>
+
+                <!-- New Sound Settings Section -->
+                <h2 class="section-title text-2xl font-semibold mt-6 mb-3 text-center">Sound Settings</h2>
+                <div class="flex items-center justify-center p-4">
+                    <label for="master-sound-toggle" class="mr-4 text-sm font-medium text-gray-300">Master Sound</label>
+                    <div class="relative inline-flex items-center cursor-pointer">
+                        <input type="checkbox" id="master-sound-toggle" class="sr-only peer">
+                        <div class="w-11 h-6 bg-gray-600 peer-focus:outline-none peer-focus:ring-4 peer-focus:ring-blue-800 rounded-full peer peer-checked:after:translate-x-full peer-checked:after:border-white after:content-[''] after:absolute after:top-[2px] after:left-[2px] after:bg-white after:border-gray-300 after:border after:rounded-full after:h-5 after:w-5 after:transition-all peer-checked:bg-blue-600"></div>
+                        <span id="master-sound-status-text" class="ml-3 text-sm font-medium text-gray-300">On</span>
+                    </div>
+                </div>
             </div>
         </div>
     </div>
@@ -843,7 +854,16 @@ document.addEventListener('DOMContentLoaded', () => {
         }
 
        async function playTone(duration, toneFrequency) {
-            if (stopMorseCode || !audioContext) return; // Check stop flag and audio context
+            // Check master sound setting FIRST
+            if (typeof window.isMasterSoundEnabled !== 'undefined' && !window.isMasterSoundEnabled) {
+                // console.log('Master sound is OFF, playTone will not play.'); // Debug log
+                return Promise.resolve(); // Exit if master sound is disabled
+            }
+
+            if (stopMorseCode || !audioContext) {
+                // console.warn("playTone: stopMorseCode active or no audioContext. Aborting tone."); // Optional log
+                return Promise.resolve(); // Correctly return a resolved promise
+            }
 
             return new Promise(resolve => {
                 if (!audioContext || audioContext.state === 'suspended') {

--- a/js/settings.js
+++ b/js/settings.js
@@ -1,3 +1,36 @@
+// Master sound setting
+let isMasterSoundEnabled = true; // Default value
+
+function loadMasterSoundSetting() {
+    const savedSetting = localStorage.getItem('masterSoundEnabled');
+    if (savedSetting !== null) {
+        isMasterSoundEnabled = JSON.parse(savedSetting); // Ensure boolean
+    }
+    // If nothing in localStorage, it remains true (the default)
+    console.log('Master sound setting loaded:', isMasterSoundEnabled);
+    // Ensure the global variable is updated after loading
+    window.isMasterSoundEnabled = isMasterSoundEnabled;
+}
+
+function saveMasterSoundSetting() {
+    localStorage.setItem('masterSoundEnabled', JSON.stringify(window.isMasterSoundEnabled));
+    console.log('Master sound setting saved:', window.isMasterSoundEnabled);
+}
+
+// Load the setting when the script is initialized
+loadMasterSoundSetting();
+
+// Make isMasterSoundEnabled accessible globally
+window.isMasterSoundEnabled = isMasterSoundEnabled;
+
+// Provide a way for other scripts to update it through a setter
+window.setMasterSoundEnabled = function(value) {
+    window.isMasterSoundEnabled = value;
+    saveMasterSoundSetting();
+    // Potentially dispatch an event if other parts of the UI need to react instantly
+    // window.dispatchEvent(new CustomEvent('masterSoundSettingChanged', { detail: { isEnabled: window.isMasterSoundEnabled } }));
+};
+
 document.addEventListener('DOMContentLoaded', () => {
     const unitTimeInput = document.getElementById('unit-time-input');
     const currentUnitTimeDisplay = document.getElementById('current-unit-time-display');
@@ -26,6 +59,32 @@ document.addEventListener('DOMContentLoaded', () => {
     // Initialize the UI with the current UNIT_TIME_MS from visualTapper.js
     // This relies on getVisualTapperUnitTime being a global function from visualTapper.js
     // and visualTapper.js having executed its localStorage load logic.
+
+    // New code for Master Sound Toggle
+    const masterSoundToggle = document.getElementById('master-sound-toggle');
+    const masterSoundStatusText = document.getElementById('master-sound-status-text');
+
+    if (!masterSoundToggle || !masterSoundStatusText) {
+        console.error("Master sound UI elements (master-sound-toggle or master-sound-status-text) not found. Master sound script adjustments will not initialize.");
+        // We don't return here, as other settings might still be configurable.
+        // However, the following lines related to masterSoundToggle will fail if elements are missing.
+        // Thus, their specific logic should be conditional on their existence.
+    }
+
+    if (masterSoundToggle && masterSoundStatusText) {
+        // Initialize UI based on the loaded setting
+        // window.isMasterSoundEnabled should be already loaded by loadMasterSoundSetting() called at the start of the script.
+        masterSoundToggle.checked = window.isMasterSoundEnabled;
+        masterSoundStatusText.textContent = window.isMasterSoundEnabled ? 'On' : 'Off';
+
+        // Add event listener for changes on the toggle
+        masterSoundToggle.addEventListener('change', () => {
+            const newState = masterSoundToggle.checked;
+            window.setMasterSoundEnabled(newState); // Updates global var and saves to localStorage
+            masterSoundStatusText.textContent = newState ? 'On' : 'Off';
+            console.log('Master Sound toggled to:', newState ? 'On' : 'Off');
+        });
+    }
     if (typeof getVisualTapperUnitTime === 'function') {
         updateSettingsUI(getVisualTapperUnitTime());
     } else {
@@ -35,59 +94,61 @@ document.addEventListener('DOMContentLoaded', () => {
         updateSettingsUI(150); // Default visual
     }
 
-    // Event listener for the input field
-    unitTimeInput.addEventListener('input', () => {
-        const rawValue = unitTimeInput.value;
-        const newValue = parseInt(rawValue);
-        const min = parseInt(unitTimeInput.min);
-        const max = parseInt(unitTimeInput.max);
-        const feedbackEl = document.getElementById('unit-time-save-feedback');
+    // Event listener for the input field (ensure it exists before adding listener)
+    if (unitTimeInput) {
+        unitTimeInput.addEventListener('input', () => {
+            const rawValue = unitTimeInput.value;
+            const newValue = parseInt(rawValue);
+            const min = parseInt(unitTimeInput.min);
+            const max = parseInt(unitTimeInput.max);
+            const feedbackEl = document.getElementById('unit-time-save-feedback');
 
-        if (rawValue === '') { // Handle empty input - could be intermediate state or cleared
-            if (feedbackEl) {
-                feedbackEl.textContent = 'Please enter a value.';
-                feedbackEl.className = 'text-sm ml-2 feedback-message text-red-500';
-                setTimeout(() => { feedbackEl.textContent = ''; }, 3000);
+            if (rawValue === '') { // Handle empty input - could be intermediate state or cleared
+                if (feedbackEl) {
+                    feedbackEl.textContent = 'Please enter a value.';
+                    feedbackEl.className = 'text-sm ml-2 feedback-message text-red-500';
+                    setTimeout(() => { feedbackEl.textContent = ''; }, 3000);
+                }
+                // Do not revert yet, user might be typing
+                return;
             }
-            // Do not revert yet, user might be typing
-            return;
-        }
 
-        if (isNaN(newValue) || newValue < min || newValue > max) {
-            if (feedbackEl) {
-                feedbackEl.textContent = `Invalid: Must be ${min}-${max}ms.`;
-                feedbackEl.className = 'text-sm ml-2 feedback-message text-red-500';
-                setTimeout(() => { feedbackEl.textContent = ''; }, 3000);
+            if (isNaN(newValue) || newValue < min || newValue > max) {
+                if (feedbackEl) {
+                    feedbackEl.textContent = `Invalid: Must be ${min}-${max}ms.`;
+                    feedbackEl.className = 'text-sm ml-2 feedback-message text-red-500';
+                    setTimeout(() => { feedbackEl.textContent = ''; }, 3000);
+                }
+                // Revert to the last known good value if getVisualTapperUnitTime is available and reliable
+                if (typeof getVisualTapperUnitTime === 'function') {
+                    unitTimeInput.value = getVisualTapperUnitTime();
+                }
+                return; // Don't proceed with saving or updating if invalid
             }
-            // Revert to the last known good value if getVisualTapperUnitTime is available and reliable
-            if (typeof getVisualTapperUnitTime === 'function') {
-                unitTimeInput.value = getVisualTapperUnitTime();
-            }
-            return; // Don't proceed with saving or updating if invalid
-        }
 
-        // If valid, proceed with updateVisualTapperUnitTime and "Saved!" feedback
-        if (typeof updateVisualTapperUnitTime === 'function') {
-            updateVisualTapperUnitTime(newValue); // This function should also update global UNIT_TIME_MS
-            if (feedbackEl) {
-                feedbackEl.textContent = 'Saved!';
-                feedbackEl.className = 'text-sm ml-2 feedback-message text-green-500';
-                setTimeout(() => { feedbackEl.textContent = ''; }, 2000);
+            // If valid, proceed with updateVisualTapperUnitTime and "Saved!" feedback
+            if (typeof updateVisualTapperUnitTime === 'function') {
+                updateVisualTapperUnitTime(newValue); // This function should also update global UNIT_TIME_MS
+                if (feedbackEl) {
+                    feedbackEl.textContent = 'Saved!';
+                    feedbackEl.className = 'text-sm ml-2 feedback-message text-green-500';
+                    setTimeout(() => { feedbackEl.textContent = ''; }, 2000);
+                }
+            } else {
+                console.error("updateVisualTapperUnitTime function is not defined globally. Cannot update tapper speed.");
+                if (feedbackEl) {
+                    feedbackEl.textContent = 'Error saving settings!';
+                    feedbackEl.className = 'text-sm ml-2 feedback-message text-red-500';
+                    setTimeout(() => { feedbackEl.textContent = ''; }, 2000);
+                }
             }
-        } else {
-            console.error("updateVisualTapperUnitTime function is not defined globally. Cannot update tapper speed.");
-            if (feedbackEl) {
-                feedbackEl.textContent = 'Error saving settings!';
-                feedbackEl.className = 'text-sm ml-2 feedback-message text-red-500';
-                setTimeout(() => { feedbackEl.textContent = ''; }, 2000);
-            }
-        }
 
-        // Update the UI display for current effective value (already handled by updateSettingsUI if UNIT_TIME_MS changes)
-        // but if updateVisualTapperUnitTime directly updates UNIT_TIME_MS, then call updateSettingsUI with that.
-        // For now, assuming updateVisualTapperUnitTime handles the underlying UNIT_TIME_MS update.
-        // The current updateSettingsUI(newValue) below might be redundant if UNIT_TIME_MS is the source of truth.
-        // Let's ensure updateSettingsUI is called with the *actual* applied value (which is newValue here as it's validated).
-        updateSettingsUI(newValue);
-    });
+            // Update the UI display for current effective value (already handled by updateSettingsUI if UNIT_TIME_MS changes)
+            // but if updateVisualTapperUnitTime directly updates UNIT_TIME_MS, then call updateSettingsUI with that.
+            // For now, assuming updateVisualTapperUnitTime handles the underlying UNIT_TIME_MS update.
+            // The current updateSettingsUI(newValue) below might be redundant if UNIT_TIME_MS is the source of truth.
+            // Let's ensure updateSettingsUI is called with the *actual* applied value (which is newValue here as it's validated).
+            updateSettingsUI(newValue);
+        });
+    }
 });

--- a/js/visualTapper.js
+++ b/js/visualTapper.js
@@ -75,6 +75,12 @@ document.addEventListener('DOMContentLoaded', () => {
 
     // Sound functions using Tone.js (if available)
     function playTapSound() {
+        // Check master sound setting FIRST
+        if (typeof window.isMasterSoundEnabled !== 'undefined' && !window.isMasterSoundEnabled) {
+            // console.log('Master sound is OFF, playTapSound will not play.'); // Debug log
+            return; // Exit if master sound is disabled
+        }
+
         if (typeof Tone !== 'undefined' && Tone && Tone.Synth) {
             if (!tapperTone) {
                 try {


### PR DESCRIPTION
I've implemented a global master sound toggle in the application settings. This allows you to mute or unmute all sounds produced by the application.

Key changes:
- Added a UI toggle switch in the "Settings" tab.
- Introduced a global JavaScript variable `isMasterSoundEnabled` to manage the sound state.
- The state of this setting is saved to and loaded from `localStorage`, persisting across sessions.
- Modified `playTapSound` in `js/visualTapper.js` and `playTone` in `index.html` to respect the master sound toggle. If the toggle is off, these functions will not produce sound.
- The UI toggle reflects the current setting and updates the global variable and localStorage when changed.