### PR TITLE
feat: Overhaul Book Cipher game view layout and add Morse highlighting

### DIFF
--- a/index.html
+++ b/index.html
@@ -261,6 +261,32 @@
         color: white; /* Ensure text is white on blue background */
     }
 
+    /* For Book Cipher Highlighting */
+    .current-morse-target {
+        background-color: #f6e05e; /* Tailwind yellow-300 */
+        color: #1a202c;           /* Tailwind gray-900 */
+        font-weight: bold;
+        padding: 0.1em 0.25em;     /* Use em for padding relative to font size */
+        border-radius: 3px;
+        box-shadow: 0 0 5px #f6e05e; /* Optional: add a subtle glow */
+        transition: background-color 0.2s ease-in-out, color 0.2s ease-in-out; /* Smooth transition */
+    }
+
+    .morse-char-span {
+        /* Add a little padding to each span so highlight doesn't look too cramped */
+        padding: 0.05em;
+    }
+
+    /* Ensure the full morse display has good contrast and readability */
+    #full-book-morse-display {
+        font-family: 'Courier New', Courier, monospace; /* Monospaced font for Morse */
+        font-size: 1.1rem; /* Slightly larger font for readability */
+        line-height: 1.6;  /* Adjust line spacing */
+        /* max-height: 400px; /* Already set in HTML, confirm it's good */
+        /* overflow-y: auto; /* Already set in HTML */
+        /* background-color: #1f2937; /* Slightly different shade if needed, current is gray-700 */
+    }
+
     </style>
 </head>
 <body>
@@ -372,36 +398,30 @@
 
                 <div id="book-details-view" class="hidden"></div>
 
-                <div id="book-game-view" class="hidden">
-                    <div id="bookCipherTapperArea" class="text-center my-4">
-                        <!-- The shared visual tapper will be inserted here by JavaScript -->
-                    </div>
+                <div id="book-game-view" class="hidden"> <!-- Existing outer container -->
+                    <div class="flex flex-col md:flex-row gap-4"> <!-- Main flex container for two columns -->
+                        <!-- Left Column: Full Morse Display -->
+                        <div id="full-book-morse-display" class="md:w-2/3 p-3 bg-gray-700 border border-gray-600 rounded-md text-gray-300 whitespace-pre-wrap word-wrap-break-word overflow-y-auto" style="max-height: 400px;">
+                            Full Morse code will appear here...
+                        </div>
 
-                    <!-- Obscured/Target Text Display -->
-                    <div class="mb-4">
-                        <label for="target-text-display" class="block mb-2 text-sm font-medium text-gray-300">Target Morse Segment:</label>
-                        <div id="target-text-display" class="p-3 min-h-[100px] bg-gray-700 border border-gray-600 rounded-md text-gray-300 whitespace-pre-wrap word-wrap-break-word">Morse code will appear here...</div>
-                    </div>
+                        <!-- Right Column: Tapper, Unlocked Text, Current Target -->
+                        <div class="md:w-1/3 flex flex-col gap-4">
+                            <div id="bookCipherTapperArea" class="text-center my-4">
+                                <!-- The shared visual tapper will be inserted here by JavaScript -->
+                            </div>
 
-                    <!-- Unlocked Text Display -->
-                    <div class="mb-4">
-                        <label for="unlocked-text-display" class="block mb-2 text-sm font-medium text-gray-300">Your Unlocked Text:</label>
-                        <div id="unlocked-text-display" class="p-3 min-h-[100px] bg-gray-700 border border-gray-600 rounded-md text-gray-300 whitespace-pre-wrap word-wrap-break-word">-</div>
-                    </div>
+                            <div>
+                                <label for="unlocked-text-display" class="block mb-2 text-sm font-medium text-gray-300">Your Unlocked Text:</label>
+                                <div id="unlocked-text-display" class="p-3 min-h-[100px] bg-gray-700 border border-gray-600 rounded-md text-gray-300 whitespace-pre-wrap word-wrap-break-word">-</div>
+                            </div>
 
-                    <!-- Current Decoded Character Display -->
-                    <div class="mb-4 text-center">
-                        <label for="current-decoded-char" class="block mb-2 text-sm font-medium text-gray-300">Current Target Morse Letter:</label>
-                        <div id="current-decoded-char" class="p-2 bg-gray-700 rounded-md text-xl font-mono text-center min-w-[50px] inline-block text-gray-300">-</div>
+                            <div class="text-center"> <!-- Centering the current target display -->
+                                <label for="current-decoded-char" class="block mb-2 text-sm font-medium text-gray-300">Current Target Morse Letter:</label>
+                                <div id="current-decoded-char" class="p-2 bg-gray-700 rounded-md text-2xl font-mono text-center min-w-[60px] inline-block text-gray-300">-</div>
+                            </div>
+                        </div>
                     </div>
-
-                    <!-- Morse Input/Output Area -->
-                    <div class="mb-6">
-                        <label for="book-cipher-morse-io" class="block text-sm font-medium text-gray-300 mb-2">Morse Input/Output:</label>
-                        <textarea id="book-cipher-morse-io" class="input-output-box w-full focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500" placeholder="Morse input/output for book cipher..."></textarea>
-                    </div>
-
-                    <!-- Start Button (Removed from here) -->
                 </div> <!-- End of book-game-view -->
             </div>
         </div>


### PR DESCRIPTION
I've implemented a new two-column layout for the Book Cipher game view:
- The left column displays the full Morse code of the selected book, scrollable.
- The right column contains the Morse tapper, the unlocked English text display, and a display for the current target Morse letter.

Key changes:
- I modified `index.html` to introduce the new layout structure for `#book-game-view`, including a new `#full-book-morse-display` div. Obsolete elements like `#target-text-display` and `#book-cipher-morse-io` were removed.
- I updated `js/bookCipher.js` (`initializeAndStartBookGame`) to populate `#full-book-morse-display` with the complete Morse code of the book, formatted for readability. Each Morse letter is wrapped in a `<span>` with unique data attributes.
- I implemented JavaScript logic in `setNextTargetMorseSignal` to dynamically highlight the current target Morse letter within `#full-book-morse-display` by applying/removing a CSS class. This function also updates `#current-decoded-char` and scrolls the highlighted Morse letter into view.
- I added CSS rules to `index.html` for the `.current-morse-target` highlighting style and improved typography for the Morse code display.
- I ensured the initial game state correctly highlights the first Morse letter and initializes the unlocked text area.
- Calls to the now-obsolete `displayCurrentWordInUI` function were removed from the JavaScript.