### PR TITLE
feat: Add 'Return to Library' button in Book Cipher game view

### DIFF
--- a/index.html
+++ b/index.html
@@ -437,6 +437,8 @@
                                 <label for="current-decoded-char" class="block mb-2 text-sm font-medium text-gray-300">Current Target Morse Letter:</label>
                                 <div id="current-decoded-char" class="p-2 bg-gray-700 rounded-md text-2xl font-mono text-center min-w-[60px] inline-block text-gray-300">-</div>
                             </div>
+
+                            <button id="return-to-library-from-game-btn" class="mt-4 w-full bg-gray-600 hover:bg-gray-700 active:bg-gray-800 text-white font-semibold py-2 px-4 rounded-md transition-colors duration-300 ease-in-out focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-offset-gray-800 focus:ring-gray-500">Return to Library</button>
                         </div>
                     </div>
                 </div> <!-- End of book-game-view -->

--- a/js/bookCipher.js
+++ b/js/bookCipher.js
@@ -29,6 +29,7 @@ document.addEventListener('DOMContentLoaded', () => {
     const unlockedTextDisplay = document.getElementById('unlocked-text-display');
     const currentDecodedCharDisplay = document.getElementById('current-decoded-char');
     const bookCipherMessageEl = document.getElementById('book-cipher-message'); // Added
+    const returnToLibraryFromGameBtn = document.getElementById('return-to-library-from-game-btn');
 
     // --- View Switching Functions ---
     function showBookLibraryView() {
@@ -731,6 +732,24 @@ document.addEventListener('DOMContentLoaded', () => {
 
     // Initial state for Morse IO: disabled until a book is successfully loaded
     // if(bookCipherMorseIO) bookCipherMorseIO.disabled = true; // Removed, as bookCipherMorseIO is removed
+
+    if (returnToLibraryFromGameBtn) {
+        returnToLibraryFromGameBtn.addEventListener('click', () => {
+            console.log("'Return to Library' button clicked from game view.");
+            if (currentBookId) { // currentBookId is a global in this file
+                // isBookCompleted is also a global in this file
+                saveProgress(currentBookId, isBookCompleted);
+            }
+            // detachSharedTapper is a global function from index.html
+            if (typeof detachSharedTapper === 'function') {
+                detachSharedTapper();
+            } else {
+                console.error("detachSharedTapper function not found. Tapper may not be handled correctly.");
+            }
+            // showBookLibraryView is defined in this file
+            showBookLibraryView();
+        });
+    }
 
     // Populate the book library on DOMContentLoaded
     populateBookLibrary();


### PR DESCRIPTION
I've implemented a 'Return to Library' button within the Book Cipher's game view. This allows you to stop your current deciphering session and return to the book library.

Changes include:
- Added a 'Return to Library' button to `index.html` within the `#book-game-view` section.
- Implemented JavaScript logic in `js/bookCipher.js`:
  - The button click saves the current progress (if a book is active) using `saveProgress()`.
  - Calls `detachSharedTapper()` to hide and reset the shared tapper.
  - Calls `showBookLibraryView()` to switch back to the library interface.

This enhances navigation and your control within the Book Cipher feature. I recommend manual testing to verify progress saving/loading, tapper state, and view transitions.