### PR TITLE
Fix: Prevent state leak between Book Cipher and Learn & Practice tabs

### DIFF
--- a/index.html
+++ b/index.html
@@ -851,6 +851,11 @@ function showTab(tabIdToShow) {
         selectedNavButton.classList.add('bg-blue-600', 'text-white');
     }
 
+    // If switching to the Learn & Practice tab, start a new challenge.
+    if (tabIdToShow === 'learn-practice-tab' && typeof startNewChallenge === 'function') {
+        startNewChallenge();
+    }
+
     // Attach tapper to the new tab if it's the book cipher tab or learn & practice tab
     if (tabIdToShow === 'book-cipher-tab') {
         attachTapperToArea('bookCipherTapperArea');

--- a/js/bookCipher.js
+++ b/js/bookCipher.js
@@ -728,6 +728,11 @@ if (typeof attachTapperToArea === 'function') {
     // and the full book display is managed by #full-book-morse-display.
 
     document.addEventListener('visualTapperCharacterComplete', (event) => {
+    const bookCipherTab = document.getElementById('book-cipher-tab');
+    if (bookCipherTab && bookCipherTab.classList.contains('hidden')) {
+        return; // Do nothing if the Book Cipher tab is not active
+    }
+
         if (event.detail && typeof event.detail.morseString === 'string') {
             const morseFromTapper = event.detail.morseString;
             // console.log('BookCipher: Received visualTapperCharacterComplete with Morse:', morseFromTapper);

--- a/js/learnPracticeGame.js
+++ b/js/learnPracticeGame.js
@@ -159,6 +159,11 @@ document.addEventListener('DOMContentLoaded', () => {
     }
 
     document.addEventListener('visualTapperCharacterComplete', (event) => {
+    const learnPracticeTab = document.getElementById('learn-practice-tab');
+    if (learnPracticeTab && learnPracticeTab.classList.contains('hidden')) {
+        return; // Do nothing if the Learn & Practice tab is not active
+    }
+
         if (!currentChallengeWord) return; // Ignore taps if no challenge is active
 
         const morseString = event.detail.morseString;


### PR DESCRIPTION
This commit resolves an issue where tapper input could leak between the "Book Cipher" and "Learn & Practice" tabs.

I made the following changes:
- Modified the `visualTapperCharacterComplete` event listener in `js/learnPracticeGame.js` to only process events if the "Learn & Practice" tab is active (not hidden).
- Modified the `visualTapperCharacterComplete` event listener in `js/bookCipher.js` to only process events if the "Book Cipher" tab is active (not hidden).
- Updated the `showTab(tabIdToShow)` function in `index.html` to call `startNewChallenge()` whenever the "Learn & Practice" tab is selected. This ensures the practice game state is reset, providing a fresh challenge and clearing any previous input each time you navigate to this tab.

These changes ensure that tapper input is correctly scoped to the active tab and that the "Learn & Practice" game provides a consistent experience by resetting on activation.