### PR TITLE
Fix: Resolve UI overlap in shared visual tapper component

### DIFF
--- a/index.html
+++ b/index.html
@@ -561,12 +561,12 @@
     <div id="hiddenTapperStorage" style="display: none;"></div>
     <div id="sharedVisualTapperWrapper" style="display: none;">
         <div class="tapper-section-container text-center my-4">
-            <div class="tapper-area inline-block mr-2">
-                <div class="tapper-container">
-                    <div id="tapper" class="tapper shadow-lg mx-auto">Tap!</div>
-                </div>
+            <!-- New flex container for tapper and button -->
+            <div class="flex justify-center items-center gap-4 mb-4">
+                <div id="tapper" class="tapper shadow-lg">Tap!</div> <!-- Removed mx-auto as flex handles centering -->
+                <button id="spaceButton" title="End Letter" class="text-sm bg-blue-500 hover:bg-blue-700 active:bg-blue-800 text-white font-semibold py-2 px-3 rounded-full h-14 w-14 flex items-center justify-center transition-colors duration-300 ease-in-out focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500">End<br>Ltr</button>
             </div>
-            <button id="spaceButton" title="End Letter" class="align-middle text-sm bg-blue-500 hover:bg-blue-700 active:bg-blue-800 text-white font-semibold py-2 px-3 rounded-full h-14 w-14 flex items-center justify-center transition-colors duration-300 ease-in-out focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500">End<br>Ltr</button>
+            <!-- Output area remains below -->
             <div class="output-area mt-2">
                 <h3 class="text-lg font-semibold mb-1">Your Morse:</h3>
                 <p id="tapperMorseOutput" class="text-xl font-mono min-h-[25px] break-all bg-gray-700 p-2 rounded"></p>


### PR DESCRIPTION
I refactored the HTML structure of the `sharedVisualTapperWrapper` to prevent the "Your Morse:" output area from overlapping with the "End Ltr" button.

- I wrapped the tapper div and "End Ltr" button in a new parent div.
- I applied Tailwind CSS Flexbox classes (`flex justify-center items-center gap-4 mb-4`) to the new wrapper to position the tapper and button side-by-side with proper alignment and spacing.
- I ensured the "Your Morse:" output area (`output-area`) is positioned sequentially below the new flex container.
- I removed redundant wrapper divs (`tapper-area`, `tapper-container`) to simplify the HTML structure.

This change ensures the tapper and its "End Ltr" button appear together, with the "Your Morse:" output displayed cleanly below them, addressing the reported UI overlap.