### PR TITLE
Fix: Refine Morse reference table for full visibility

### DIFF
--- a/index.html
+++ b/index.html
@@ -320,8 +320,6 @@
                                             <th>Morse</th>
                                             <th>Character</th>
                                             <th>Morse</th>
-                                            <th>Character</th>
-                                            <th>Morse</th>
                                         </tr>
                                     </thead>
                                     <tbody id="morse-reference-body">
@@ -1053,7 +1051,7 @@ document.addEventListener('DOMContentLoaded', () => {
     const characters = Object.keys(morseCode);
     let rowContent = '';
     for (let i = 0; i < characters.length; i++) {
-        if (i % 3 === 0) { // Start new row
+        if (i % 2 === 0) { // Start new row
             if (i > 0) rowContent += '</tr>';
             rowContent += '<tr>';
         }
@@ -1086,9 +1084,9 @@ document.addEventListener('DOMContentLoaded', () => {
         rowContent += `<td id="ref-char-${idChar}">${displayChar}</td><td id="ref-morse-${idChar}">${morseCode[char]}</td>`;
 
         if (i === characters.length - 1) { // Ensure last row is closed correctly
-            let cellsInLastRow = (i % 3) + 1; // Number of items processed for the current row
-            if (cellsInLastRow < 3) {
-                for (let j = cellsInLastRow; j < 3; j++) {
+            let cellsInLastRow = (i % 2) + 1; // Number of items processed for the current row
+            if (cellsInLastRow < 2) {
+                for (let j = cellsInLastRow; j < 2; j++) {
                     rowContent += '<td></td><td></td>'; // Add empty pairs for missing items
                 }
             }


### PR DESCRIPTION
This commit resolves a UI issue where the "Morse Code Reference" table in the "Learn & Practice" tab was being cut off horizontally.

The table structure was updated to have two pairs of "Character" / "Morse" columns instead of three. The JavaScript logic for populating the table was also adjusted accordingly to ensure the table is narrower and fully visible without requiring horizontal scrolling.

- Modified `index.html` to change the table header from 6 columns to 4.
- Updated the `populateMorseReference` function in `index.html` to reflect the new two-column-pair structure, changing the row creation logic from `i % 3` to `i % 2` and adjusting the padding of the last row.