### PR TITLE
Fix: Adjust main content area to use full screen width

### DIFF
--- a/index.html
+++ b/index.html
@@ -24,7 +24,6 @@
             border-radius: 8px;
             box-shadow: 0 4px 15px rgba(0, 0, 0, 0.5);
             width: 100%;
-            max-width: 800px; /* Max width for larger screens */
         }
         .main-title {
             color: #4a90e2; /* A bright blue for the title */
@@ -67,6 +66,10 @@
         .tab-content {
             width: 100%; /* Ensure it spans the full width available */
             /* e.g., padding-top: 1rem; */
+        }
+
+        #tab-content-wrapper {
+            width: 100%;
         }
 
         /* Tapper CSS */


### PR DESCRIPTION
This commit modifies the CSS to allow the main content container (.app-container) to expand to the full available width of the browser on large screens.

Changes made:
- Removed `max-width: 800px;` from the `.app-container` CSS rule in `index.html`.
- Added a new CSS rule for `#tab-content-wrapper` in `index.html` with `width: 100%;` to ensure its children can expand fully.

These changes improve the utilization of screen real estate on larger displays while maintaining responsiveness on smaller screens.