### PR TITLE
Refactor: Adjust Learn & Practice column widths

### DIFF
--- a/index.html
+++ b/index.html
@@ -310,9 +310,9 @@
         <div id="learn-practice-tab" class="tab-content">
             <div class="app-container">
                 <!-- NEW TOP CONTAINER STARTS HERE -->
-                <div class="w-full flex flex-col space-y-4 md:flex-row md:space-x-4 md:items-start mb-6">
+                <div class="w-full flex flex-col space-y-4 md:grid md:grid-cols-3 md:gap-4 md:items-start mb-6">
                     <!-- Left column for Morse reference -->
-                    <div class="w-full md:w-1/2 p-2">
+                    <div class="w-full p-2 md:col-span-2">
                         <div class="morse-reference">
                             <h2 class="section-title text-2xl font-semibold mb-3 text-center">Morse Code Reference</h2>
                             <div class="">
@@ -333,7 +333,7 @@
                         </div>
                     </div>
                     <!-- Right column for Tapper -->
-                    <div class="w-full md:w-1/2 p-2">
+                    <div class="w-full p-2">
                         <div id="learnPracticeTapperArea" class="text-center my-4">
                             <!-- The shared visual tapper will be inserted here by JavaScript -->
                              <h2 class="section-title text-2xl font-semibold mb-3 text-center">Practice Tapping Morse</h2>


### PR DESCRIPTION
I've modified the two-column layout in the "Learn & Practice" tab to prioritize the Morse Code Reference table.

- I changed the main container from a flexbox layout (`md:flex-row`) to a grid layout (`md:grid md:grid-cols-3`) on medium screens and up.
- I assigned the Morse Code Reference table container to span two columns (`md:col-span-2`).
- The tapper area container now automatically occupies the remaining single column.

This change ensures the reference table has more horizontal space and is fully visible on wider screens, while maintaining a stacked layout on smaller screens for responsiveness.