### PR TITLE
Refactor: Relocate Learn & Practice game controls

### DIFF
--- a/index.html
+++ b/index.html
@@ -337,6 +337,11 @@
                         <div id="learnPracticeTapperArea" class="text-center my-4">
                             <!-- The shared visual tapper will be inserted here by JavaScript -->
                              <h2 class="section-title text-2xl font-semibold mb-3 text-center">Practice Tapping Morse</h2>
+                            <div class="mt-4 flex flex-col space-y-2">
+                                <button id="newChallengeButton" class="mt-2 w-full bg-green-500 hover:bg-green-700 active:bg-green-800 text-white font-semibold py-2 px-4 rounded-md transition-colors duration-300 ease-in-out focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-green-500">New Challenge</button>
+                                <button id="play-tapped-morse-btn" class="mt-2 w-full bg-purple-500 hover:bg-purple-700 active:bg-purple-800 text-white font-semibold py-2 px-4 rounded-md transition-colors duration-300 ease-in-out focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-purple-500 disabled:opacity-50 disabled:cursor-not-allowed" disabled>Play My Tapped Morse</button>
+                                <button id="clearTapperInputButton" class="mt-2 w-full bg-red-500 hover:bg-red-700 active:bg-red-800 text-white font-semibold py-2 px-4 rounded-md transition-colors duration-300 ease-in-out focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-red-500">Clear My Tapping</button>
+                            </div>
                         </div>
                     </div>
                 </div>
@@ -347,9 +352,6 @@
                     <p id="practiceText" class="text-3xl font-bold text-yellow-400 min-h-[40px] text-center"></p>
                     <p id="tapperDecodedOutput" class="text-2xl min-h-[30px] break-all text-center bg-gray-700 p-2 rounded mt-2"></p>
                     <p id="practiceMessage" class="text-lg text-center min-h-[24px] mt-2"></p>
-                    <button id="newChallengeButton" class="mt-2 w-full bg-green-500 hover:bg-green-700 active:bg-green-800 text-white font-semibold py-2 px-4 rounded-md transition-colors duration-300 ease-in-out focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-green-500">New Challenge</button>
-                    <button id="play-tapped-morse-btn" class="mt-2 w-full bg-purple-500 hover:bg-purple-700 active:bg-purple-800 text-white font-semibold py-2 px-4 rounded-md transition-colors duration-300 ease-in-out focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-purple-500 disabled:opacity-50 disabled:cursor-not-allowed" disabled>Play My Tapped Morse</button>
-                    <button id="clearTapperInputButton" class="mt-2 w-full bg-red-500 hover:bg-red-700 active:bg-red-800 text-white font-semibold py-2 px-4 rounded-md transition-colors duration-300 ease-in-out focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-red-500">Clear My Tapping</button>
                 </div>
                 <!-- End Interactive Practice Game Area -->
 


### PR DESCRIPTION
I've moved the "New Challenge," "Play My Tapped Morse," and "Clear My Tapping" buttons from the 'interactivePracticeGame' div to below the tapper component within the 'learnPracticeTapperArea' div in the "Learn & Practice" tab.

The buttons are wrapped in a new div with Tailwind CSS classes (mt-4 flex flex-col space-y-2) for proper vertical stacking and spacing. This change consolidates tapping-related interactions into a single area.