### PR TITLE
feat: Implement word space input and refine tapper

### DIFF
--- a/index.html
+++ b/index.html
@@ -568,7 +568,7 @@
             <!-- New flex container for tapper and button -->
             <div class="flex justify-center items-center gap-4 mb-4">
                 <div id="tapper" class="tapper shadow-lg">Tap!</div> <!-- Removed mx-auto as flex handles centering -->
-                <button id="spaceButton" title="End Letter" class="text-sm bg-blue-500 hover:bg-blue-700 active:bg-blue-800 text-white font-semibold py-2 px-3 rounded-full h-14 w-14 flex items-center justify-center transition-colors duration-300 ease-in-out focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500">End<br>Ltr</button>
+                <button id="spaceButton" title="End Letter" class="text-sm bg-blue-500 hover:bg-blue-700 active:bg-blue-800 text-white font-semibold py-2 px-3 rounded-full h-14 w-14 flex items-center justify-center transition-colors duration-300 ease-in-out focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500">Word<br>Space</button>
             </div>
             <!-- Output area remains below -->
             <div class="output-area mt-2">
@@ -1115,7 +1115,10 @@ document.addEventListener('DOMContentLoaded', () => {
         }
 
         const char = characters[i];
-        const displayChar = char === ' ' ? 'Space' : char;
+        if (char === ' ') {
+            continue; // Skip the space character for the reference table
+        }
+        const displayChar = char === ' ' ? 'Space' : char; // This line is now somewhat redundant for 'Space' but harmless
         let idChar = char;
         if (char === '.') idChar = 'Period';
         else if (char === ',') idChar = 'Comma';

--- a/js/learnPracticeGame.js
+++ b/js/learnPracticeGame.js
@@ -158,30 +158,41 @@ document.addEventListener('DOMContentLoaded', () => {
         });
     }
 
-    document.addEventListener('visualTapperCharacterComplete', (event) => {
-    const learnPracticeTab = document.getElementById('learn-practice-tab');
-    if (learnPracticeTab && learnPracticeTab.classList.contains('hidden')) {
-        return; // Do nothing if the Learn & Practice tab is not active
-    }
+    document.addEventListener('visualTapperInput', (event) => {
+        const learnPracticeTab = document.getElementById('learn-practice-tab');
+        if (learnPracticeTab && learnPracticeTab.classList.contains('hidden')) {
+            return; // Do nothing if the Learn & Practice tab is not active
+        }
 
         if (!currentChallengeWord) return; // Ignore taps if no challenge is active
 
-        const morseString = event.detail.morseString;
-        if (morseString) { // Ensure there's a Morse string to decode
-            const decodedChar = getCharFromMorse(morseString);
-            if (decodedChar) {
-                checkPractice(decodedChar);
-            } else {
-                // This case means the tapper completed a sequence, but it's not valid Morse.
-                // visualTapper.js already handles showing "Unknown Morse" locally.
-                // Here, we might want to provide feedback in the game context.
-                practiceMessage.textContent = `Unknown Morse: ${morseString}. Try again.`;
-                practiceMessage.style.color = '#F59E0B'; // Tailwind amber-500 (similar to orange)
+        const detail = event.detail;
+        if (!detail) return; // No detail object
+
+        if (detail.type === 'char') {
+            const morseString = detail.value;
+            if (morseString) { // Ensure there's a Morse string to decode
+                const decodedChar = getCharFromMorse(morseString);
+                if (decodedChar) {
+                    checkPractice(decodedChar); // This function already updates tapperDecodedOutput and currentTappedString
+                } else {
+                    practiceMessage.textContent = `Unknown Morse: ${morseString}. Try again.`;
+                    practiceMessage.style.color = '#F59E0B'; // Tailwind amber-500
+                }
             }
-        } else {
-            // This can happen if the spaceButton is pressed when currentMorse in tapper is empty.
-            // For this game, it doesn't represent a character input, so we can ignore it.
-            // console.log("Learn & Practice: visualTapperCharacterComplete with empty morseString.");
+        } else if (detail.type === 'word_space') {
+            // Append a literal space
+            currentTappedString += ' ';
+            tapperDecodedOutput.textContent = currentTappedString;
+            updatePlayTappedMorseButtonState();
+            // Optionally, provide feedback or move to next word if that's part of the game logic
+            // For now, just adding a space.
+            practiceMessage.textContent = "Space added.";
+            practiceMessage.style.color = 'lightblue'; // Or some neutral color
+            // If we want to check if the space was correctly placed (e.g., end of a word in challenge):
+            // if (currentTappedString.trim() === currentChallengeWord.substring(0, currentTappedString.length).trim() && currentTappedString.endsWith(' ')) {
+            //     // Potentially part of a multi-word challenge, or just confirming space.
+            // }
         }
     });
 

--- a/js/visualTapper.js
+++ b/js/visualTapper.js
@@ -216,15 +216,22 @@ document.addEventListener('DOMContentLoaded', () => {
         }
 
         // Dispatch custom event for other modules (like bookCipher.js) to consume
-        // Dispatch even if morseStringForEvent is empty, if it's an explicit action (space button)
-        if (morseStringForEvent || isExplicitAction) {
-            const event = new CustomEvent('visualTapperCharacterComplete', {
-                detail: {
-                    morseString: morseStringForEvent 
-                }
+        let eventDetail = null;
+
+        if (morseStringForEvent && morseStringForEvent.length > 0) {
+            // A character was completed
+            eventDetail = { type: 'char', value: morseStringForEvent };
+        } else if (isExplicitAction && currentMorse.length === 0) {
+            // Space button clicked and no Morse code was pending (i.e., it's an intentional word space)
+            eventDetail = { type: 'word_space' };
+        }
+
+        if (eventDetail) {
+            const event = new CustomEvent('visualTapperInput', {
+                detail: eventDetail
             });
             document.dispatchEvent(event);
-            // console.log("VisualTapper: Dispatched visualTapperCharacterComplete with morse:", morseStringForEvent);
+            // console.log("VisualTapper: Dispatched visualTapperInput with detail:", eventDetail);
         }
         
         currentMorse = ""; // Clear Morse buffer for the next character


### PR DESCRIPTION
This commit introduces a dedicated "Word Space" functionality to the Morse code tapper and updates consuming modules.

Key changes:
- UI: Relabeled the tapper's space button from "End Ltr" to "Word Space" for clarity.
- Tapper Event:
    - Renamed `visualTapperCharacterComplete` event to `visualTapperInput`.
    - The `visualTapperInput` event now dispatches a `detail` object with a `type` field:
        - `{ type: 'char', value: '...' }` for completed Morse characters.
        - `{ type: 'word_space' }` when the "Word Space" button is used with an empty buffer.
- Event Consumers:
    - `learnPracticeGame.js` and `bookCipher.js` updated to listen for `visualTapperInput`.
    - Logic added to both consumers to handle `event.detail.type`:
        - `'char'`: Processes the Morse value as before.
        - `'word_space'`: Appends a literal space to the respective output displays.
- Morse Reference: Removed the "Space /" entry from the Morse code reference table in `index.html` as word spaces are not tapped as dot-dash sequences.