### PR TITLE
Refactor: Consolidate Learn & Practice UI elements into right column

### DIFF
--- a/index.html
+++ b/index.html
@@ -337,36 +337,31 @@
                         <div id="learnPracticeTapperArea" class="text-center my-4 flex flex-col items-center">
                             <!-- The shared visual tapper will be inserted here by JavaScript -->
                              <h2 class="section-title text-2xl font-semibold mb-3 text-center">Practice Tapping Morse</h2>
+                            <p id="practiceText" class="text-3xl font-bold text-yellow-400 min-h-[40px] text-center"></p>
                             <div id="tapper-placeholder"></div> <!-- New placeholder -->
                             <div id="tapperGameControls" class="mt-4 flex flex-col space-y-2"> <!-- Moved and ID'd button container -->
                                 <button id="newChallengeButton" class="mt-2 w-full bg-green-500 hover:bg-green-700 active:bg-green-800 text-white font-semibold py-2 px-4 rounded-md transition-colors duration-300 ease-in-out focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-green-500">New Challenge</button>
                                 <button id="play-tapped-morse-btn" class="mt-2 w-full bg-purple-500 hover:bg-purple-700 active:bg-purple-800 text-white font-semibold py-2 px-4 rounded-md transition-colors duration-300 ease-in-out focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-purple-500 disabled:opacity-50 disabled:cursor-not-allowed" disabled>Play My Tapped Morse</button>
                                 <button id="clearTapperInputButton" class="mt-2 w-full bg-red-500 hover:bg-red-700 active:bg-red-800 text-white font-semibold py-2 px-4 rounded-md transition-colors duration-300 ease-in-out focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-red-500">Clear My Tapping</button>
                             </div>
+                            <p id="tapperDecodedOutput" class="text-2xl min-h-[30px] break-all text-center bg-gray-700 p-2 rounded mt-2"></p>
+                            <p id="practiceMessage" class="text-lg text-center min-h-[24px] mt-2"></p>
+                            <hr class="my-6 border-gray-600">
+                            <!-- Receive & Type Morse Challenge Area -->
+                            <div id="receiveTypeChallengeArea" class="mt-8 pt-6 border-t border-gray-600">
+                                <h2 class="section-title text-2xl font-semibold mb-3 text-center">Receive & Type Morse Challenge</h2>
+                                <div class="flex flex-col items-center space-y-4">
+                                    <button id="playReceiveChallengeButton" class="w-full md:w-auto bg-yellow-500 hover:bg-yellow-700 active:bg-yellow-800 text-white font-semibold py-2 px-4 rounded-md transition-colors duration-300 ease-in-out focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-yellow-500">Play Morse Challenge</button>
+                                    <input type="text" id="receiveChallengeInput" class="w-full md:w-3/4 lg:w-1/2 text-center bg-gray-700 border border-gray-600 text-white py-2 px-4 rounded-md focus:outline-none focus:ring-2 focus:ring-yellow-500 focus:border-yellow-500 placeholder-gray-400" placeholder="Type your decoded text here..." disabled>
+                                    <button id="submitReceiveChallengeButton" class="w-full md:w-auto bg-green-500 hover:bg-green-700 active:bg-green-800 text-white font-semibold py-2 px-4 rounded-md transition-colors duration-300 ease-in-out focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-green-500" disabled>Submit Answer</button>
+                                    <p id="receiveChallengeFeedback" class="text-lg text-center min-h-[24px] mt-2"></p>
+                                </div>
+                            </div>
+                            <!-- End Receive & Type Morse Challenge Area -->
                         </div>
                     </div>
                 </div>
                 <!-- NEW TOP CONTAINER ENDS HERE -->
-
-                <!-- Interactive Practice Game Area -->
-                <div id="interactivePracticeGame">
-                    <p id="practiceText" class="text-3xl font-bold text-yellow-400 min-h-[40px] text-center"></p>
-                    <p id="tapperDecodedOutput" class="text-2xl min-h-[30px] break-all text-center bg-gray-700 p-2 rounded mt-2"></p>
-                    <p id="practiceMessage" class="text-lg text-center min-h-[24px] mt-2"></p>
-                </div>
-                <!-- End Interactive Practice Game Area -->
-
-                <!-- Receive & Type Morse Challenge Area -->
-                <div id="receiveTypeChallengeArea" class="mt-8 pt-6 border-t border-gray-600">
-                    <h2 class="section-title text-2xl font-semibold mb-3 text-center">Receive & Type Morse Challenge</h2>
-                    <div class="flex flex-col items-center space-y-4">
-                        <button id="playReceiveChallengeButton" class="w-full md:w-auto bg-yellow-500 hover:bg-yellow-700 active:bg-yellow-800 text-white font-semibold py-2 px-4 rounded-md transition-colors duration-300 ease-in-out focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-yellow-500">Play Morse Challenge</button>
-                        <input type="text" id="receiveChallengeInput" class="w-full md:w-3/4 lg:w-1/2 text-center bg-gray-700 border border-gray-600 text-white py-2 px-4 rounded-md focus:outline-none focus:ring-2 focus:ring-yellow-500 focus:border-yellow-500 placeholder-gray-400" placeholder="Type your decoded text here..." disabled>
-                        <button id="submitReceiveChallengeButton" class="w-full md:w-auto bg-green-500 hover:bg-green-700 active:bg-green-800 text-white font-semibold py-2 px-4 rounded-md transition-colors duration-300 ease-in-out focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-green-500" disabled>Submit Answer</button>
-                        <p id="receiveChallengeFeedback" class="text-lg text-center min-h-[24px] mt-2"></p>
-                    </div>
-                </div>
-                <!-- End Receive & Type Morse Challenge Area -->
 
                 <div class="controls mb-6 text-center">
             <button id="play-morse-btn" class="mr-2 bg-blue-600 hover:bg-blue-700 active:bg-blue-800 text-white font-semibold py-2 px-4 rounded-md transition-colors duration-300 ease-in-out focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500">Play Morse Code</button>


### PR DESCRIPTION
Moves all interactive elements for both "Tap Challenge Word" and "Receive & Type" practice modes into the right-hand column (#learnPracticeTapperArea) on the "Learn & Practice" tab.

The changes include:
- Relocated "Tapped Answer" (#tapperDecodedOutput) and "Message" (#practiceMessage) displays from #interactivePracticeGame to #learnPracticeTapperArea.
- Relocated the entire "Receive & Type Morse Challenge" UI (#receiveTypeChallengeArea) into #learnPracticeTapperArea.
- Added a visual separator (<hr>) between the two practice mode sections within the right column.
- Moved the "Challenge Word" display (#practiceText) from #interactivePracticeGame to #learnPracticeTapperArea, placing it under the main heading for the tapping section.
- Removed the now-empty #interactivePracticeGame div.

This refactoring centralizes the interactive components for a cleaner and more logical layout as per the issue specification.