### PR TITLE
feat: Add reset progress functionality to Koch method

### DIFF
--- a/index.html
+++ b/index.html
@@ -737,6 +737,12 @@
                         <input type="text" id="koch-answer-input" maxlength="1" class="text-center text-2xl font-semibold p-3 rounded-md bg-gray-800 text-white border border-gray-600 focus:ring-2 focus:ring-blue-500 focus:border-blue-500 w-3/4 md:w-1/2 lg:w-1/4 uppercase placeholder-gray-500" placeholder="Type character here">
                         <p id="koch-feedback-message" class="text-lg text-center min-h-[28px] font-medium"></p> <!-- Adjusted min-height -->
                     </div>
+                    <!-- Reset Button -->
+                    <div class="mt-6 text-center">
+                        <button id="koch-reset-progress-btn" class="w-full md:w-auto bg-red-600 hover:bg-red-700 active:bg-red-800 text-white font-semibold py-2 px-4 rounded-md transition-colors duration-300 ease-in-out focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-offset-gray-800 focus:ring-red-500 text-sm">
+                            Reset Koch Progress
+                        </button>
+                    </div>
                 </div>
             </div>
         </div>
@@ -1466,7 +1472,7 @@ document.addEventListener('DOMContentLoaded', () => {
     <script src="js/morsePals.js" defer></script>
     <script src="js/kochMethod.js" defer></script>
 
-    <!-- Unlocked Text Modal -->
+    <!-- Unlocked Text Modal (Book Cipher) -->
     <div id="unlocked-text-modal" class="fixed inset-0 bg-gray-900 bg-opacity-75 flex items-center justify-center p-4 hidden z-50">
         <div class="bg-gray-800 p-6 rounded-lg shadow-xl max-w-2xl w-full max-h-[80vh] flex flex-col">
             <h3 id="unlocked-text-modal-title" class="text-xl font-semibold text-white mb-4">Unlocked Book Text</h3>
@@ -1474,6 +1480,22 @@ document.addEventListener('DOMContentLoaded', () => {
                 <!-- Full text will be loaded here -->
             </div>
             <button id="close-unlocked-text-modal-btn" class="mt-6 bg-blue-600 hover:bg-blue-700 text-white font-semibold py-2 px-4 rounded-md self-center">Close</button>
+        </div>
+    </div>
+
+    <!-- Koch Method Reset Confirmation Modal -->
+    <div id="koch-reset-modal" class="fixed inset-0 bg-gray-900 bg-opacity-75 flex items-center justify-center p-4 hidden z-50">
+        <div class="bg-gray-800 p-6 rounded-lg shadow-xl max-w-md w-full">
+            <h3 class="text-xl font-semibold text-white mb-4">Confirm Reset</h3>
+            <p class="text-gray-300 mb-6">Are you sure you want to reset your Koch Method progress? All unlocked characters and accuracy stats will be lost.</p>
+            <div class="flex justify-end space-x-3">
+                <button id="koch-cancel-reset-btn" class="px-4 py-2 text-sm font-medium text-gray-300 bg-gray-600 hover:bg-gray-700 rounded-md focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-offset-gray-800 focus:ring-gray-500">
+                    Cancel
+                </button>
+                <button id="koch-confirm-reset-btn" class="px-4 py-2 text-sm font-medium text-white bg-red-600 hover:bg-red-700 rounded-md focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-offset-gray-800 focus:ring-red-500">
+                    Confirm Reset
+                </button>
+            </div>
         </div>
     </div>
 </body>

--- a/js/kochMethod.js
+++ b/js/kochMethod.js
@@ -31,7 +31,8 @@ loadUnlockedCharacters();
 // (Rest of the Koch method logic will be added here in subsequent steps)
 
 // DOM Elements
-let kochStartBtn, kochPlayBtn, kochAnswerInput, kochAccuracyDisplay, kochCharSetDisplay, kochFeedbackMessage, kochLevelsContainer;
+let kochStartBtn, kochPlayBtn, kochAnswerInput, kochAccuracyDisplay, kochCharSetDisplay, kochFeedbackMessage, kochLevelsContainer,
+    kochResetProgressBtn, kochResetModal, kochConfirmResetBtn, kochCancelResetBtn;
 
 // Function to populate Koch Levels display
 function populateKochLevels() {
@@ -140,6 +141,10 @@ document.addEventListener('DOMContentLoaded', () => {
     kochCharSetDisplay = document.getElementById('koch-char-set-display');
     kochFeedbackMessage = document.getElementById('koch-feedback-message');
     kochLevelsContainer = document.getElementById('koch-levels-container');
+    kochResetProgressBtn = document.getElementById('koch-reset-progress-btn');
+    kochResetModal = document.getElementById('koch-reset-modal');
+    kochConfirmResetBtn = document.getElementById('koch-confirm-reset-btn');
+    kochCancelResetBtn = document.getElementById('koch-cancel-reset-btn');
 
     // Initial UI setup
     if (kochPlayBtn) kochPlayBtn.classList.add('hidden');
@@ -241,7 +246,71 @@ document.addEventListener('DOMContentLoaded', () => {
     console.log("Koch Method script loaded and DOM elements initialized.");
     console.log("Initial Unlocked Characters:", unlockedCharacters);
     console.log("Initial Session Stats:", sessionStats);
+
+    // Event listeners for reset functionality
+    if (kochResetProgressBtn) {
+        kochResetProgressBtn.addEventListener('click', () => {
+            if (kochResetModal) kochResetModal.classList.remove('hidden');
+        });
+    }
+
+    if (kochConfirmResetBtn) {
+        kochConfirmResetBtn.addEventListener('click', () => {
+            resetKochProgress();
+        });
+    }
+
+    if (kochCancelResetBtn) {
+        kochCancelResetBtn.addEventListener('click', () => {
+            if (kochResetModal) kochResetModal.classList.add('hidden');
+        });
+    }
+
+    // Optional: Close modal if user clicks outside of it (on the overlay)
+    if (kochResetModal) {
+        kochResetModal.addEventListener('click', (event) => {
+            if (event.target === kochResetModal) { // Check if the click is on the overlay itself
+                kochResetModal.classList.add('hidden');
+            }
+        });
+    }
 });
+
+// Function to reset Koch Method progress
+function resetKochProgress() {
+    localStorage.removeItem('kochUnlockedCharacters');
+    unlockedCharacters = [kochCharacterOrder[0], kochCharacterOrder[1]]; // Reset to first two
+    localStorage.setItem('kochUnlockedCharacters', JSON.stringify(unlockedCharacters));
+
+    sessionStats = { correct: 0, total: 0 }; // Reset session stats
+
+    updateKochDisplays(); // Update all UI elements
+
+    if (kochFeedbackMessage) {
+        kochFeedbackMessage.textContent = "Progress reset successfully!";
+        kochFeedbackMessage.className = 'text-lg text-center min-h-[28px] font-medium text-green-400'; // Success style
+        setTimeout(() => {
+            if (kochFeedbackMessage.textContent === "Progress reset successfully!") {
+                kochFeedbackMessage.textContent = ''; // Clear after a few seconds
+                kochFeedbackMessage.className = 'text-lg text-center min-h-[28px] font-medium'; // Reset class
+            }
+        }, 3000);
+    }
+
+    if (kochResetModal) {
+        kochResetModal.classList.add('hidden'); // Hide the modal
+    }
+
+    // Ensure the UI state for practice session is reset (e.g., show start button)
+    if (kochStartBtn) kochStartBtn.classList.remove('hidden');
+    if (kochPlayBtn) kochPlayBtn.classList.add('hidden');
+    if (kochAnswerInput) {
+        kochAnswerInput.disabled = true;
+        kochAnswerInput.value = '';
+    }
+    console.log("Koch method progress has been reset.");
+}
+
 
 // Function to handle session completion (to be fully implemented in Step 3)
 function handleSessionCompletion(accuracy) {


### PR DESCRIPTION
Implemented a feature allowing users to reset their progress in the Koch method trainer.

- Added a 'Reset Progress' button to the Koch method UI.
- Added a confirmation modal to prevent accidental data loss.
- The reset action clears unlocked characters from localStorage, resets them to the initial two characters, and clears session statistics.
- UI elements (character set, accuracy, level display) are updated accordingly upon reset.
- The practice session controls are also reset to their initial state.