### PR TITLE
Feat: Implement mobile-optimized bottom navigation bar

### DIFF
--- a/index.html
+++ b/index.html
@@ -13,7 +13,7 @@
             background-color: #1a1a1a; /* Dark background */
             color: #f0f0f0; /* Light text */
             margin: 0;
-            padding: 20px;
+            /* padding: 20px; Adjusted by Tailwind classes now for responsive nav */
             display: flex;
             flex-direction: column;
             align-items: center;
@@ -475,8 +475,8 @@
 
     </style>
 </head>
-<body>
-    <nav class="flex justify-center mb-4 space-x-2">
+<body class="pt-5 pb-20 md:pb-5"> {/* Added padding for nav bars */}
+    <nav class="flex justify-center space-x-2 fixed bottom-0 left-0 right-0 z-50 bg-gray-800 p-2 shadow-md md:relative md:top-auto md:left-auto md:right-auto md:bg-transparent md:shadow-none md:mb-4 md:p-0">
         <button id="learn-practice-nav-btn" data-tab="learn-practice-tab" class="px-4 py-2 text-sm font-medium text-white bg-blue-600 rounded-md hover:bg-blue-700 active:bg-blue-800 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 active-tab-button">Learn & Practice</button>
         <button id="morse-io-nav-btn" data-tab="morse-io-tab" class="px-4 py-2 text-sm font-medium text-gray-300 bg-gray-700 rounded-md hover:bg-gray-600 active:bg-gray-800 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-gray-500">Morse I/O</button>
         <button id="book-cipher-nav-btn" data-tab="book-cipher-tab" class="px-4 py-2 text-sm font-medium text-gray-300 bg-gray-700 rounded-md hover:bg-gray-600 active:bg-gray-800 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-gray-500">Book Cipher</button>


### PR DESCRIPTION
Refactored the main navigation bar to be fixed at the bottom on mobile devices and remain at the top on larger screens.

- Modified <nav> element CSS classes in index.html using Tailwind CSS.
- Default style is fixed to the bottom for mobile.
- md: prefix used to make it a static top navigation bar on medium screens and up.
- Adjusted <body> padding to account for the bottom navigation bar height on mobile, preventing content obscuring.