### PR TITLE
feat: Redesign Learn & Practice tab for mobile with predictive tapper

### DIFF
--- a/www/index.html
+++ b/www/index.html
@@ -494,7 +494,8 @@
                 <div class="w-full flex flex-col space-y-4 md:grid md:grid-cols-3 md:gap-4 md:items-start mb-6">
                     <!-- Left column for Morse reference -->
                     <div class="w-full p-2 md:col-span-2">
-                        <div class="morse-reference" id="morse-reference-container">
+                        <button id="toggle-reference-btn" class="md:hidden w-full bg-blue-500 hover:bg-blue-700 text-white font-semibold py-2 px-4 rounded-md mb-4">Show Morse Reference</button>
+                        <div class="morse-reference hidden md:block" id="morse-reference-container">
                             <h2 class="section-title text-2xl font-semibold mb-3 text-center">Morse Code Reference</h2>
                             <div class="">
                                 <table class="reference-table mx-auto">
@@ -713,7 +714,9 @@
     <div id="hiddenTapperStorage" style="display: none;"></div>
     <div id="sharedVisualTapperWrapper" style="display: none;">
         <div class="tapper-section-container text-center my-4">
-            <!-- New flex container for tapper and button -->
+            <!-- Predictive Taps Display -->
+            <div id="predictive-taps-display" class="min-h-[3em] p-2 mb-2 text-center text-lg text-gray-400 border border-gray-600 rounded-md"></div>
+            <!-- Flex container for tapper and button -->
             <div class="flex justify-center items-center gap-4 mb-4">
                 <div id="tapper" class="tapper shadow-lg">Tap!</div> <!-- Removed mx-auto as flex handles centering -->
                 <button id="spaceButton" title="End Letter" class="text-sm bg-blue-500 hover:bg-blue-700 active:bg-blue-800 text-white font-semibold py-2 px-3 rounded-full h-14 w-14 flex items-center justify-center transition-colors duration-300 ease-in-out focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500">Word<br>Space</button>

--- a/www/js/visualTapper.js
+++ b/www/js/visualTapper.js
@@ -166,6 +166,7 @@ document.addEventListener('DOMContentLoaded', () => {
         
         if (tapperMorseOutput) tapperMorseOutput.textContent = currentMorse;
         if (typeof window.updateTableHighlight === "function") window.updateTableHighlight(currentMorse); // Ensure this is active for highlighting
+        updatePredictiveDisplay(currentMorse); // Update predictive display
         tapStartTime = 0; // Reset for the next tap
 
         // Start the timer to detect end of a letter
@@ -224,6 +225,7 @@ document.addEventListener('DOMContentLoaded', () => {
         currentMorse = ""; // Clear Morse buffer for the next character
         if (tapperMorseOutput) tapperMorseOutput.textContent = currentMorse; // Update display
         if (typeof window.updateTableHighlight === "function") window.updateTableHighlight(currentMorse); // Called with "" to clear highlight
+        updatePredictiveDisplay(currentMorse); // Clear predictive display when Morse is cleared
         checkPractice(); // Dummy call
     }
 
@@ -267,6 +269,40 @@ document.addEventListener('DOMContentLoaded', () => {
     }
 });
 
+// Function to update the predictive display
+function updatePredictiveDisplay(morseString) {
+    const displayElement = document.getElementById('predictive-taps-display');
+    if (!displayElement) {
+        // console.warn("Predictive taps display element not found.");
+        return;
+    }
+
+    if (!morseString || morseString.length === 0) {
+        displayElement.textContent = ""; // Clear display if morseString is empty
+        return;
+    }
+
+    const possibleChars = [];
+    // Ensure morseCode is available (it's defined in index.html's script tag)
+    if (typeof morseCode === 'undefined') {
+        console.error("morseCode dictionary is not available to updatePredictiveDisplay.");
+        displayElement.textContent = "Error: Morse dictionary unavailable.";
+        return;
+    }
+
+    for (const char in morseCode) {
+        if (morseCode[char].startsWith(morseString)) {
+            possibleChars.push(char);
+        }
+    }
+
+    if (possibleChars.length > 0) {
+        displayElement.textContent = `Possible: ${possibleChars.join(', ')}`;
+    } else {
+        displayElement.textContent = "No match";
+    }
+}
+
 // Globally accessible reset function for the visual tapper state
 function resetVisualTapperState() {
     currentMorse = "";
@@ -292,4 +328,18 @@ function resetVisualTapperState() {
     // Temporarily commenting out to isolate the "updateTableHighlight is not defined" error
     // if (typeof window.updateTableHighlight === "function") window.updateTableHighlight(""); 
     console.log("VisualTapper state reset. (updateTableHighlight call commented out for testing)");
+    updatePredictiveDisplay(""); // Clear predictive display on reset
+
+    // Event listener for the toggle reference button
+    const toggleReferenceBtn = document.getElementById('toggle-reference-btn');
+    const morseReferenceContainer = document.getElementById('morse-reference-container');
+
+    if (toggleReferenceBtn && morseReferenceContainer) {
+        toggleReferenceBtn.addEventListener('click', () => {
+            const isHidden = morseReferenceContainer.classList.toggle('hidden');
+            toggleReferenceBtn.textContent = isHidden ? 'Show Morse Reference' : 'Hide Morse Reference';
+        });
+    } else {
+        console.warn("Could not find toggle reference button or container for collapsible functionality.");
+    }
 }


### PR DESCRIPTION
Implements the following changes:

1.  **Collapsible Morse Reference Table (Mobile):**
    *   The large Morse reference table in the "Learn & Practice" tab is now hidden by default on mobile viewports.
    *   A "Show/Hide Morse Reference" button is available on mobile to toggle the table's visibility.
    *   On larger screens (desktop), the table remains visible by default, and the toggle button is hidden.

2.  **Predictive Taps Display:**
    *   A new UI element (`#predictive-taps-display`) has been added directly above the visual tapper.
    *   This display provides real-time feedback by showing possible Morse characters based on the user's current input sequence (dots and dashes).
    *   The display updates after each tap and clears when a character is decoded or the input is reset.

These changes enhance the mobile user experience by making the tapper more prominent and providing immediate, helpful feedback, while retaining full functionality on desktop.