### PR TITLE
Fix: Stabilize tapper layout and improve event handling

### DIFF
--- a/www/index.html
+++ b/www/index.html
@@ -720,7 +720,7 @@
     <div id="sharedVisualTapperWrapper" style="display: none;">
         <div class="tapper-section-container text-center my-4">
             <!-- Predictive Taps Display -->
-            <div id="predictive-taps-display" class="min-h-[3em] p-2 mb-2 text-center text-lg text-gray-400 border border-gray-600 rounded-md"></div>
+                <div id="predictive-taps-display" class="h-[3em] p-2 mb-2 text-center text-lg text-gray-400 border border-gray-600 rounded-md"></div>
             <!-- Flex container for tapper and button -->
             <div class="flex justify-center items-center gap-4 mb-4">
                 <div id="tapper" class="tapper shadow-lg">Tap!</div> <!-- Removed mx-auto as flex handles centering -->

--- a/www/js/visualTapper.js
+++ b/www/js/visualTapper.js
@@ -134,9 +134,9 @@ document.addEventListener('DOMContentLoaded', () => {
     
     // Event Listeners for the Tapper UI using Pointer Events
     tapper.addEventListener('pointerdown', (e) => {
+        e.preventDefault(); // Prevent text selection and other default browser actions
         // Check if the event is from the primary pointer to avoid multi-touch issues if not desired
         if (!e.isPrimary) return;
-        e.preventDefault(); // Prevent text selection and other default browser actions
         if (isPlayingBack) return; // Placeholder: if some playback mode is active, ignore taps
 
         // Capture the pointer to ensure subsequent pointer events (like pointerup, pointermove) are received


### PR DESCRIPTION
- Set a fixed height for the predictive taps display to prevent layout shift.
- Made pointerdown event handling more aggressive by calling preventDefault() earlier.