### PR TITLE
Style: Increase size of predictive display tooltip

### DIFF
--- a/www/index.html
+++ b/www/index.html
@@ -288,9 +288,11 @@
 
     <div id="hiddenTapperStorage" style="display: none;"></div>
     <div id="sharedVisualTapperWrapper" style="display: none;">
-        <div class="tapper-section-container text-center my-2 md:my-4"> <!-- Adjusted my-4 to my-2 md:my-4 -->
-            <!-- Predictive Taps Display -->
-                <div id="predictive-taps-display" class="h-[2.8em] md:h-[3em] p-1 md:p-2 mb-1 md:mb-2 text-center text-base md:text-lg text-gray-400 border border-gray-600 rounded-md" style="height: 3em;"></div>
+        <div class="tapper-section-container text-center my-2 md:my-4 relative"> <!-- Added position: relative -->
+            <!-- Predictive Taps Display (Tooltip Style) -->
+            <div id="predictive-taps-display" class="absolute bottom-full left-1/2 transform -translate-x-1/2 mb-2 w-80 bg-gray-800 text-white p-2 rounded-md shadow-lg max-h-36 overflow-y-auto z-10 border border-gray-600 hidden">
+                <!-- Pills will be dynamically inserted here -->
+            </div>
             <!-- Flex container for tapper and button -->
             <div class="flex justify-center items-center gap-2 md:gap-4 mb-2 md:mb-3">
                 <div id="tapper" class="tapper shadow-lg">Tap!</div> <!-- Removed mx-auto as flex handles centering -->


### PR DESCRIPTION
- Increased max-height to max-h-36.
- Set width to w-80 for a wider display area.

This should allow more predictive pills to be visible.