### PR TITLE
Fix: Ensure Koch method text input is visible on desktop

### DIFF
--- a/www/js/kochMethod.js
+++ b/www/js/kochMethod.js
@@ -172,6 +172,7 @@ document.addEventListener('DOMContentLoaded', () => {
             if (kochPlayBtn) kochPlayBtn.classList.remove('hidden');
             if (kochAnswerInput) {
                 kochAnswerInput.disabled = false;
+                kochAnswerInput.classList.remove('hidden'); // Ensure input field is visible
                 kochAnswerInput.value = ''; // Clear previous input
                 // On mobile, focus might not be desired if using on-screen buttons.
                 // On desktop, it's good.


### PR DESCRIPTION
The Koch method character input field (`koch-answer-input`) was not reliably appearing on desktop browsers when a practice session started.

This change explicitly removes the 'hidden' class from the input field via JavaScript when the session starts, ensuring it becomes visible. The existing Tailwind class `md:block` will then correctly manage its display type on desktop screens.