### PR TITLE
Feat: Implement Markdown rendering for Book Cipher unlocked text

### DIFF
--- a/www/index.html
+++ b/www/index.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="css/style.css">
     <script src="https://cdnjs.cloudflare.com/ajax/libs/tone/14.8.49/Tone.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/canvas-confetti@1.5.1/dist/confetti.browser.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"></script>
     <style>
         /* Styles moved to www/css/style.css */
     </style>

--- a/www/js/data/bookData.js
+++ b/www/js/data/bookData.js
@@ -1,7 +1,21 @@
 window.bookCipherBooks = {
     // Free Books (first 3-5)
-    'passage_1': { title: 'Sherlock Holmes Snippet', filePath: 'assets/book_cipher_texts/passage1_morse.txt', author: "Placeholder Author", description: "A short snippet for practice.", isPro: false },
-    'mystery_intro': { title: 'Stormy Night Mystery', filePath: 'assets/book_cipher_texts/mystery_intro_morse.txt', author: "Placeholder Author", description: "The beginning of a thrilling mystery.", isPro: false },
+    'passage_1': {
+        title: 'Sherlock Holmes Snippet',
+        filePath: 'assets/book_cipher_texts/passage1_morse.txt',
+        author: "Sir Arthur Conan Doyle",
+        description: "A short snippet featuring the world's most famous detective.",
+        isPro: false,
+        english_markdown: "### The Adventures of Sherlock Holmes\n\n**To Sherlock Holmes she is always _the_ woman.**\n\nI have seldom heard him mention her under any other name. In his eyes she eclipses and predominates the whole of her sex. It was not that he felt any emotion akin to love for Irene Adler. All emotions, and that one particularly, were abhorrent to his cold, precise but admirably balanced mind.\n\n---\n\n*A Scandal in Bohemia*"
+    },
+    'mystery_intro': {
+        title: 'Stormy Night Mystery',
+        filePath: 'assets/book_cipher_texts/mystery_intro_morse.txt',
+        author: "Placeholder Author",
+        description: "The beginning of a thrilling mystery.",
+        isPro: false,
+        english_markdown: "### Chapter 1: The Gathering Storm\n\nThe wind howled like a banshee, rattling the ancient windowpanes of Blackwood Manor. Rain lashed down in relentless sheets, obscuring the winding path that led to the imposing oak door. Inside, a fire crackled in the grand hearth, casting flickering shadows on the faces of the assembled guests.\n\nEach had received a mysterious invitation. None knew why they were truly there.\n\n**Tonight, a secret will be revealed.**\n\n*Someone in this room is not who they claim to be...*"
+    },
     'sci_fi_quote': { title: 'Sci-Fi Classic Quote', filePath: 'assets/book_cipher_texts/sci_fi_quote_morse.txt', author: "Placeholder Author", description: "A famous quote from a sci-fi classic.", isPro: false },
     'short_book': { title: 'Very Short Story', filePath: 'assets/book_cipher_texts/very_short_morse.txt', author: "Placeholder Author", description: "A very brief narrative for quick practice.", isPro: false },
     'pride_and_prejudice': { title: 'Pride and Prejudice Quote', filePath: 'assets/book_cipher_texts/pride_and_prejudice_morse.txt', author: 'Jane Austen', description: 'A truth universally acknowledged, from Pride and Prejudice.', isPro: false },


### PR DESCRIPTION
- Updated book data to include 'english_markdown' field.
- Added 'marked.js' library for Markdown to HTML conversion.
- Modified 'displayUnlockedBookText' to use 'english_markdown' and render HTML in the modal.
- Included fallbacks for books without Markdown and if 'marked.js' fails to load.