### PR TITLE
Update Morse tapper UI to antique key style for web and iOS

### DIFF
--- a/www/css/style.css
+++ b/www/css/style.css
@@ -327,198 +327,94 @@ nav .active-tab-button, nav .active-tab-button .text-white, nav .active-tab-butt
 
         /* New Telegraph Tapper Styles */
         .tapper-assembly {
-            display: block !important; /* Override flex for now */
-            width: 150px !important;
-            height: 150px !important; /* Increased height to ensure children fit if static */
-            background-color: red !important; /* Highly visible */
-            border: 2px solid orange !important;
-            z-index: 9999 !important;
-            padding: 5px !important; 
-            overflow: visible !important; /* Ensure children aren't clipped */
-            position: relative; /* Keep relative for children if they were to use absolute, but for static children it's less critical */
-            /* cursor: pointer; */ /* Commented out for debugging */
-            /* -webkit-user-select: none; */
-            /* -ms-user-select: none; */
-            /* user-select: none; */
-            /* -webkit-tap-highlight-color: transparent; */
-            /* touch-action: manipulation; */
-        }
-
-        .tapper-base {
-            display: block !important;
-            width: 100px !important; /* Fixed size */
-            height: 20px !important; /* Fixed size */
-            background-color: blue !important; /* Highly visible */
-            position: static !important; /* Override absolute to simplify layout initially */
-            z-index: 10000 !important; 
-            border: 1px solid lightblue !important;
-            margin-bottom: 5px !important;
-            /* Original styles commented out for debug:
-            width: 100%; 
-            height: 30px; 
-            background-color: #8B4513; 
-            border: 2px solid #5a2d0c; 
-            border-radius: 5px;
-            position: absolute;
-            bottom: 0;
-            z-index: 1;
-            */
-        }
-
-        .tapper-lever {
-            display: block !important;
-            width: 80px !important; /* Fixed size */
-            height: 50px !important; /* Fixed size */
-            background-color: green !important; /* Highly visible */
-            position: static !important; /* Override absolute */
-            margin-top: 5px !important;
-            margin-bottom: 5px !important;
-            z-index: 10001 !important;
-            border: 1px solid lightgreen !important;
-            /* Original styles commented out for debug:
-            width: 20px; 
-            height: 75px; 
-            background-color: #a98d6a; 
-            border: 1px solid #6b5335; 
-            border-radius: 3px 3px 0 0; 
-            position: absolute;
-            bottom: 25px; 
-            left: 50%;
-            transform: translateX(-50%);
-            display: flex;
-            justify-content: center;
-            align-items: flex-start; 
-            z-index: 2;
-            transition: transform 0.1s ease-out;
-            */
-        }
-
-        .tapper-key-surface {
-            display: block !important;
-            width: 40px !important; /* Fixed size */
-            height: 40px !important; /* Fixed size */
-            background-color: purple !important; /* Highly visible */
-            margin-top: 5px !important;
-            z-index: 10002 !important;
-            border: 1px solid lavender !important;
-            color: white !important; /* Ensure text is visible */
-            text-align: center !important;
-            font-size: 10px !important;
-            line-height: 40px !important; /* Vertically center text if possible */
-            /* Original styles commented out for debug:
-            width: 40px; 
-            height: 40px; 
-            background-color: #a98d6a; 
-            border: 2px solid #8b7355; 
-            border-radius: 50%; 
-            margin-top: 5px; 
-            display: flex;
-            align-items: center;
-            justify-content: center;
-            color: #fdfdf5;
-            font-family: 'Special Elite', monospace;
-            font-size: 10px; 
-            */
-        }
-        .tapper-key-surface::before {
-            content: "KEY" !important; 
-            color: white !important;
-            /* Original styles commented out for debug:
-            content: "TAP"; 
-            color: #6b5335; 
-            */
-        }
-
-
-        /* Active state for the new tapper - temporarily disable complex transforms */
-        .tapper-assembly.active .tapper-lever {
-            /* transform: translateX(-50%) translateY(3px) rotateX(5deg); */
-            /* box-shadow: 0 -1px 3px rgba(0,0,0,0.2); */
-            background-color: darkgreen !important; /* Simple active state */
-        }
-        .tapper-assembly.active .tapper-key-surface {
-            /* box-shadow: inset 0 -1px 2px rgba(0,0,0,0.4), 0 1px 1px rgba(0,0,0,0.1); */
-            /* transform: translateY(1px); */
-            background-color: darkmagenta !important; /* Simple active state */
-        }
-
-
-        #spaceButton {
-        .tapper {
-            width: 120px; /* Mobile first size */
-            height: 120px; /* Mobile first size */
+            width: 180px; /* Increased width for a more substantial base */
+            height: 120px; /* Adjusted height */
+            position: relative;
             cursor: pointer;
             -webkit-user-select: none;
             -ms-user-select: none;
             user-select: none;
             -webkit-tap-highlight-color: transparent;
-            touch-action: manipulation; /* Prevents double-tap to zoom */
+            touch-action: manipulation;
+            display: flex; /* Use flexbox to help center the lever on the base */
+            flex-direction: column;
+            align-items: center; /* Center lever horizontally */
+            justify-content: flex-end; /* Align base to the bottom, lever sits on top */
         }
 
         .tapper-base {
             width: 100%; /* Full width of assembly */
-            height: 30px; /* Height of the base */
-            background-color: #8B4513; /* SaddleBrown for wood */
+            height: 40px; /* Height of the base */
+            background: linear-gradient(to bottom, #8B4513, #7A3D0F); /* SaddleBrown to darker brown for wood grain effect */
             border: 2px solid #5a2d0c; /* Darker brown for border/shadow */
-            border-radius: 5px;
-    /* box-shadow: 0 4px 8px rgba(0,0,0,0.3), inset 0 2px 3px rgba(255,255,255,0.2); */
-            position: absolute;
-            bottom: 0;
+            border-radius: 8px; /* More rounded for a softer vintage look */
+            box-shadow: 0 6px 12px rgba(0,0,0,0.3), /* Base shadow */
+                        inset 0 2px 3px rgba(255,255,255,0.1), /* Inner highlight */
+                        inset 0 -2px 3px rgba(0,0,0,0.2); /* Inner shadow at bottom */
+            position: relative; /* Ensure it's part of the stacking context if needed, though not strictly necessary here */
             z-index: 1;
         }
 
         .tapper-lever {
-            width: 20px; /* Width of the lever arm */
+            width: 18px; /* Width of the lever arm */
             height: 75px; /* Height of the lever arm, extends above base */
-    /* background: linear-gradient(to right, #a98d6a, #8b7355); */ /* Brass gradient */
-    background-color: #a98d6a; /* Fallback solid brass color */
-            border: 1px solid #6b5335; /* Darker brass outline */
-            border-radius: 3px 3px 0 0; /* Rounded top */
-    /* box-shadow: 0 -2px 5px rgba(0,0,0,0.2); */
-            position: absolute;
-            bottom: 25px; /* Sits slightly into the base */
+            background: linear-gradient(to right, #c0c0c0, #a9a9a9, #c0c0c0); /* Silver/steel gradient */
+            border: 1px solid #708090; /* Slate gray outline */
+            border-radius: 4px 4px 0 0; /* Rounded top */
+            box-shadow: 0 -3px 6px rgba(0,0,0,0.25), /* Shadow from lever */
+                        inset 0 1px 1px rgba(255,255,255,0.3); /* Highlight on lever */
+            position: absolute; /* Position relative to tapper-assembly */
+            bottom: 30px; /* Sits slightly into the base, adjust as needed */
             left: 50%;
-            transform: translateX(-50%);
+            transform: translateX(-50%); /* Center the lever */
             display: flex;
-            justify-content: center;
-            align-items: flex-start; /* Align key to the top of the lever */
+            flex-direction: column; /* Stack key surface on top of lever part */
+            align-items: center; /* Center key surface horizontally */
+            justify-content: flex-start; /* Align key to the top of the lever */
             z-index: 2;
-            transition: transform 0.1s ease-out;
+            transition: transform 0.08s ease-out, box-shadow 0.08s ease-out;
+            transform-origin: bottom center; /* Pivot from the bottom center */
         }
 
         .tapper-key-surface {
-            width: 40px; /* Width of the key knob */
-            height: 40px; /* Height of the key knob */
-            background-color: #a98d6a; /* Brass color */
-            border: 2px solid #8b7355; /* Darker brass */
+            width: 45px; /* Width of the key knob */
+            height: 45px; /* Height of the key knob */
+            background: #333333; /* Dark gray/Bakelite color */
+            border: 2px solid #1a1a1a; /* Darker border */
             border-radius: 50%; /* Circular key */
-    /* box-shadow: inset 0 -2px 3px rgba(0,0,0,0.3), 0 2px 3px rgba(0,0,0,0.2); */
-            margin-top: 5px; /* Positioned at the top of the lever */
+            box-shadow: inset 0 -3px 4px rgba(0,0,0,0.4), /* Inner shadow for depth */
+                        inset 0 2px 3px rgba(255,255,255,0.15), /* Inner highlight */
+                        0 3px 5px rgba(0,0,0,0.3); /* Outer shadow for knob */
+            margin-top: -5px; /* Pull the key slightly down onto the lever */
             display: flex;
             align-items: center;
             justify-content: center;
-            color: #fdfdf5;
+            color: #f0f0f0; /* Light text on dark key */
             font-family: 'Special Elite', monospace;
-            font-size: 10px; /* Small text if any, or remove */
-            /* The content "TAP!" can be added via ::before or ::after if desired, or removed */
-        }
-        .tapper-key-surface::before {
-            content: "TAP"; /* Optional: text on the key */
-            color: #6b5335; /* Darker text */
+            font-size: 10px;
+            z-index: 3; /* Ensure key surface is on top of lever */
+            transition: transform 0.08s ease-out, box-shadow 0.08s ease-out;
         }
 
+        .tapper-key-surface::before {
+            content: "TAP";
+            color: #a0a0a0; /* Muted gray text */
+            font-weight: bold;
+        }
 
         /* Active state for the new tapper */
-        /* The JS adds '.active' to 'tapper-assembly' (which is the div with id="tapper") */
         .tapper-assembly.active .tapper-lever {
-            transform: translateX(-50%) translateY(3px) rotateX(5deg); /* Move lever down slightly and tilt */
-            box-shadow: 0 -1px 3px rgba(0,0,0,0.2);
-        }
-        .tapper-assembly.active .tapper-key-surface {
-            box-shadow: inset 0 -1px 2px rgba(0,0,0,0.4), 0 1px 1px rgba(0,0,0,0.1);
-            transform: translateY(1px); /* Slight press down effect on the key itself */
+            transform: translateX(-50%) rotateX(10deg); /* Tilt lever forward */
+            box-shadow: 0 -1px 3px rgba(0,0,0,0.2), inset 0 1px 1px rgba(0,0,0,0.1);
         }
 
+        .tapper-assembly.active .tapper-key-surface {
+            transform: translateY(4px) scale(0.98); /* Move key surface down and slightly shrink */
+            background: #2a2a2a; /* Slightly darker when pressed */
+            box-shadow: inset 0 -2px 3px rgba(0,0,0,0.5), /* Deeper inner shadow */
+                        inset 0 1px 2px rgba(255,255,255,0.1),
+                        0 1px 2px rgba(0,0,0,0.2); /* Reduced outer shadow */
+        }
 
         #spaceButton {
         .tapper {


### PR DESCRIPTION
- Reworked CSS for the web tapper in `www/css/style.css` to create a 3D antique Morse key appearance with a wooden base, metallic lever, and dark knob. Includes active state styling for press feedback.
- Updated the iOS tapper in `TapperMessagesExtension/ContentView.swift` using a ZStack of SwiftUI shapes to build a similar antique key. Implemented press animations for the lever and knob.