### PR TITLE
Fix: Privacy policy back button now returns to settings tab

### DIFF
--- a/www/js/main.js
+++ b/www/js/main.js
@@ -324,6 +324,20 @@ document.addEventListener('DOMContentLoaded', () => {
     // Let's assume 'learn-practice-tab' does not use the tapper initially.
     // The `showTab` function already calls `detachSharedTapper`, so this is not strictly needed here.
     // detachSharedTapper();
+
+    // Check for a targetTab in localStorage
+    try {
+        const targetTabFromStorage = localStorage.getItem('targetTab');
+        if (targetTabFromStorage) {
+            // console.log(`[main.js] Found targetTab '${targetTabFromStorage}' in localStorage. Switching to it.`);
+            showTab(targetTabFromStorage);
+            localStorage.removeItem('targetTab'); // Clean up
+        }
+        // If not found, the default tab ('introduction-tab') shown earlier remains active.
+    } catch (e) {
+        console.error("[main.js] Error accessing targetTab from localStorage:", e);
+        // Fallback or default behavior will proceed.
+    }
 });
 // --- End Tab Navigation ---
 

--- a/www/js/privacy.js
+++ b/www/js/privacy.js
@@ -21,6 +21,24 @@ document.addEventListener('DOMContentLoaded', function() {
     }
     // --- End Theme application logic ---
 
+    const backButton = document.getElementById('backButton');
+    if (backButton) {
+        backButton.addEventListener('click', function(event) {
+            const targetTab = backButton.getAttribute('data-target-tab');
+            if (targetTab) {
+                try {
+                    localStorage.setItem('targetTab', targetTab);
+                    // console.log(`[privacy.js] targetTab '${targetTab}' saved to localStorage.`);
+                } catch (e) {
+                    console.error("[privacy.js] Error saving targetTab to localStorage:", e);
+                }
+            }
+            // Allow default navigation to index.html to proceed
+        });
+    } else {
+        console.warn("[privacy.js] Back button not found. Navigation logic not attached.");
+    }
+
     const privacyPolicyContentDiv = document.getElementById('privacyPolicyContent');
     if (!privacyPolicyContentDiv) {
         console.error('Privacy policy content div not found.');

--- a/www/privacy_screen.html
+++ b/www/privacy_screen.html
@@ -9,7 +9,7 @@
 </head>
 <body class="privacy-page"> <!-- Add a class for specific targeting -->
     <div class="privacy-container container"> <!-- Add a class for specific targeting -->
-        <a href="index.html#settings" id="backButton">Back to Settings</a>
+        <a href="index.html" id="backButton" data-target-tab="settings-tab">Back to Settings</a>
         <h1>Privacy Policy</h1>
         <div id="privacyPolicyContent">
             <!-- Content will be loaded here by JavaScript -->


### PR DESCRIPTION
Modified the 'Return to Settings' button on the privacy policy page. It now correctly navigates the user back to the settings tab on the main page, instead of the default first tab.

Changes:
- `www/privacy_screen.html`: Updated button href and added data attribute.
- `www/js/privacy.js`: Added event listener to save target tab to localStorage.
- `www/js/main.js`: Added logic to check localStorage on load and switch to the target tab.