### PR TITLE
Feat: Add missing ad placeholder to Book Cipher tab

### DIFF
--- a/www/index.html
+++ b/www/index.html
@@ -178,6 +178,8 @@
                         </div>
                     </div>
                 </div> <!-- End of book-game-view -->
+                <div class="ad-placeholder-container mt-6">
+                </div>
             </div>
         </div>
         <div id="koch-method-tab" class="tab-content hidden">


### PR DESCRIPTION
Ensures that the Book Cipher tab displays an ad placeholder for free users, consistent with other app sections.

The ad visibility is handled by existing JavaScript logic in main.js (updateUserProStatusUI). This change solely adds the necessary HTML structure to the tab.