### PR TITLE
Configure: Add AdMob and App Tracking settings

### DIFF
--- a/ios/App/App/Info.plist
+++ b/ios/App/App/Info.plist
@@ -45,5 +45,16 @@
     </array>
     <key>UIViewControllerBasedStatusBarAppearance</key>
     <true/>
+    <key>GADApplicationIdentifier</key>
+    <string>ca-app-pub-3940256099942544~1458002511</string>
+    <key>SKAdNetworkItems</key>
+    <array>
+        <dict>
+            <key>SKAdNetworkIdentifier</key>
+            <string>cstr6suwn9.skadnetwork</string>
+        </dict>
+    </array>
+    <key>NSUserTrackingUsageDescription</key>
+    <string>This identifier will be used to deliver personalized ads to you.</string>
 </dict>
 </plist>

--- a/ios/App/Podfile
+++ b/ios/App/Podfile
@@ -21,4 +21,11 @@ end
 
 post_install do |installer|
   assertDeploymentTarget(installer)
+  installer.pods_project.targets.each do |target|
+    target.build_configurations.each do |config|
+      # Your existing post_install code might be here, leave it.
+      # Add the following line to manage excluded architectures.
+      config.build_settings['EXCLUDED_ARCHS[sdk=iphonesimulator*]'] = 'arm64'
+    end
+  end
 end


### PR DESCRIPTION
- Added GADApplicationIdentifier, SKAdNetworkItems, and NSUserTrackingUsageDescription to Info.plist for AdMob integration.
- Updated Podfile with a post_install hook to exclude arm64 architecture for the simulator on Apple Silicon to prevent build errors.