### PR TITLE
Refactor: Make AdMobService self-contained

### DIFF
--- a/src/js/admob.js
+++ b/src/js/admob.js
@@ -52,6 +52,11 @@ export const AdMobService = {
 
     // After initialization, setup listeners for UI adjustments
     this.setupBannerListener();
+
+    //
+    // Call showBanner() from right here!
+    //
+    this.showBanner();
   },
 
   /**

--- a/src/js/main.js
+++ b/src/js/main.js
@@ -36,10 +36,7 @@ document.addEventListener('DOMContentLoaded', () => {
     updateDurations();
 
     // --- Initialize AdMob Asynchronously in the Background ---
-    AdMobService.initialize().then(() => {
-        // This code runs only after AdMob initialization is complete.
-        AdMobService.showBanner();
-    });
+    AdMobService.initialize(); // Just call initialize and let it do its job.
 
     // --- The rest of your initialization code ---
     const masterAudioInitListener = () => {


### PR DESCRIPTION
Moved the `showBanner` call into the `initialize` function in `admob.js`. Simplified `main.js` by removing the `.then()` block from the `AdMobService.initialize()` call.

This makes the AdMobService fully responsible for initializing and showing the initial banner ad, improving stability and reducing complexity.