### PR TITLE
Fix: Decouple AdMob showBanner and add delay to prevent race condition

### DIFF
--- a/src/js/admob.js
+++ b/src/js/admob.js
@@ -10,39 +10,24 @@ export const AdMobService = {
     if (this.isInitialized) {
       return;
     }
-
     console.log('Starting AdMob initialization with UMP consent flow...');
-
-    // STEP 1: Request consent information
     const consentInfo = await AdMob.requestConsentInfo();
-
-    // STEP 2: Show consent form if required
     if (
       consentInfo.isConsentFormAvailable &&
       consentInfo.status === AdmobConsentStatus.REQUIRED
     ) {
-      console.log('UMP consent form is required. Showing form...');
       await AdMob.showConsentForm();
     }
-
-    // STEP 3: Request ATT authorization (will now work because of your phone setting)
     const trackingStatus = await AdMob.trackingAuthorizationStatus();
     if (trackingStatus.status === 'notDetermined') {
-        console.log('Requesting ATT authorization...');
         await AdMob.requestTrackingAuthorization();
     }
-
-    // STEP 4: Initialize AdMob
     await AdMob.initialize({
-      requestTrackingAuthorization: false, // We've already handled it
+      requestTrackingAuthorization: false,
       initializeForTesting: true,
     });
-
     this.isInitialized = true;
     console.log('AdMob SDK initialized successfully.');
-
-    this.setupBannerListener();
-    this.showBanner();
   },
 
   setupBannerListener() {

--- a/src/js/main.js
+++ b/src/js/main.js
@@ -36,7 +36,13 @@ document.addEventListener('DOMContentLoaded', () => {
     updateDurations();
 
     // --- Initialize AdMob Asynchronously in the Background ---
-    AdMobService.initialize(); // Just call initialize and let it do its job.
+    AdMobService.initialize().then(() => {
+        AdMobService.setupBannerListener();
+        // Add a short delay to prevent race conditions
+        setTimeout(() => {
+            AdMobService.showBanner();
+        }, 50); // 50 millisecond delay
+    });
 
     // --- The rest of your initialization code ---
     const masterAudioInitListener = () => {


### PR DESCRIPTION
Modified admob.js to only initialize the AdMob SDK in the initialize function. Modified main.js to call setupBannerListener and showBanner after successful initialization, with a 50ms delay to prevent race conditions between the webview and native AdMob view.