### PR TITLE
Refactor: Consolidate AdMob initialization and banner display

### DIFF
--- a/src/js/admob.js
+++ b/src/js/admob.js
@@ -6,11 +6,15 @@ const { AdMob, AdmobConsentStatus, BannerAdPluginEvents } = window.Capacitor.Plu
 export const AdMobService = {
   isInitialized: false,
 
+// In admob.js, inside the AdMobService object
+
   async initialize() {
     if (this.isInitialized) {
       return;
     }
     console.log('Starting AdMob initialization with UMP consent flow...');
+
+    // STEP 1: Handle Consent
     const consentInfo = await AdMob.requestConsentInfo();
     if (
       consentInfo.isConsentFormAvailable &&
@@ -18,16 +22,24 @@ export const AdMobService = {
     ) {
       await AdMob.showConsentForm();
     }
+
+    // STEP 2: Handle Tracking Authorization
     const trackingStatus = await AdMob.trackingAuthorizationStatus();
     if (trackingStatus.status === 'notDetermined') {
         await AdMob.requestTrackingAuthorization();
     }
+
+    // STEP 3: Initialize AdMob
     await AdMob.initialize({
       requestTrackingAuthorization: false,
       initializeForTesting: true,
     });
     this.isInitialized = true;
     console.log('AdMob SDK initialized successfully.');
+
+    // STEP 4: Setup Listeners and Show Banner
+    this.setupBannerListener();
+    this.showBanner();
   },
 
   setupBannerListener() {

--- a/src/js/main.js
+++ b/src/js/main.js
@@ -35,14 +35,10 @@ document.addEventListener('DOMContentLoaded', () => {
     applySavedTheme();
     updateDurations();
 
+// In main.js, inside the DOMContentLoaded listener
+
     // --- Initialize AdMob Asynchronously in the Background ---
-    AdMobService.initialize().then(() => {
-        AdMobService.setupBannerListener();
-        // Add a short delay to prevent race conditions
-        setTimeout(() => {
-            AdMobService.showBanner();
-        }, 50); // 50 millisecond delay
-    });
+    AdMobService.initialize();
 
     // --- The rest of your initialization code ---
     const masterAudioInitListener = () => {


### PR DESCRIPTION
Moved the AdMob banner display logic into the AdMobService initialize method. This ensures the banner is shown immediately after the SDK is ready, preventing potential timing issues.

Simplified the AdMob initialization call in main.js accordingly.