### PR TITLE
Fix: Ensure AdMob consent form shows on main thread

### DIFF
--- a/src/js/admob.js
+++ b/src/js/admob.js
@@ -33,8 +33,10 @@ export const AdMobService = {
       consentInfo.status === AdmobConsentStatus.REQUIRED
     ) {
       console.log('UMP consent form is required. Showing form...');
-      // Direct await ensures we wait for user interaction
-      await AdMob.showConsentForm();
+      // Wrap the call in a setTimeout to ensure it runs on the main thread
+      setTimeout(async () => {
+        await AdMob.showConsentForm();
+      }, 0);
     }
 
     // STEP 4: INITIALIZE ADMOB (only after consent is handled)


### PR DESCRIPTION
Wrapped the AdMob.showConsentForm() call in a setTimeout with a 0ms delay to ensure it executes on the main application thread. This prevents potential issues with native UI presentation during app startup.