### PR TITLE
Fix: Add delay before showing AdMob banner

### DIFF
--- a/src/js/main.js
+++ b/src/js/main.js
@@ -47,7 +47,12 @@ document.addEventListener('DOMContentLoaded', () => {
         if (state.isActive && !admobInitialized) {
             console.log('App is active, initializing AdMob...');
             admobInitialized = true; // Prevent it from running again
-            AdMobService.initialize();
+            AdMobService.initialize().then(() => {
+                // Add a small delay to ensure the UI is ready
+                setTimeout(() => {
+                    AdMobService.showBanner();
+                }, 100);
+            });
         }
     });
 


### PR DESCRIPTION
This change introduces a 100ms delay before calling `showBanner()` in the `appStateChange` listener. This is to prevent issues with the native UI not being ready when the ad is requested.