### PR TITLE
Fix: Add missing morseToText function for book cipher decoding

### DIFF
--- a/src/js/main.js
+++ b/src/js/main.js
@@ -88,6 +88,17 @@ const reversedMorseCode = {};
 for (const key in morseCode) { reversedMorseCode[morseCode[key]] = key; }
 window.reversedMorseCode = reversedMorseCode;
 
+// Function to convert a single Morse code string to its text equivalent
+function morseToText(morse) {
+    if (typeof reversedMorseCode !== 'undefined' && reversedMorseCode.hasOwnProperty(morse)) {
+        return reversedMorseCode[morse];
+    }
+    // Return empty string or a placeholder for unknown Morse code.
+    // An empty string is often less disruptive for display purposes.
+    return '';
+}
+window.morseToText = morseToText;
+
 let audioContext;
 let oscillator;
 let gainNode;


### PR DESCRIPTION
The book cipher feature was displaying an "Error: Decoding library missing." message because the `morseToText` function was undefined.

This commit defines the `morseToText` function in `src/js/main.js` and makes it globally accessible. This function uses the existing `reversedMorseCode` map to convert Morse code strings into their corresponding text characters, enabling the book cipher decoding to work correctly.