### PR TITLE
Feature/visual morse playback

### DIFF
--- a/src/css/style.css
+++ b/src/css/style.css
@@ -626,6 +626,13 @@ body:not(.light-theme) #upsell-modal .text-xs.text-gray-500 { /* Placeholder pay
   /* min-height: 50px; */
 }
 
+/* Glow effect for the play-morse-btn when active */
+#play-morse-btn.active {
+    box-shadow: 0 0 20px #f6e05e, 0 0 30px #f6e05e; /* Similar to .tapper.active glow */
+    /* The existing .active:bg-blue-800 from Tailwind will still apply for background color,
+       which is fine. We're just adding the glow. */
+}
+
 /* --- Privacy Policy Page Styles --- */
 /* Default (Light Theme) Styles for Privacy Page */
 body.privacy-page {

--- a/src/css/style.css
+++ b/src/css/style.css
@@ -626,13 +626,6 @@ body:not(.light-theme) #upsell-modal .text-xs.text-gray-500 { /* Placeholder pay
   /* min-height: 50px; */
 }
 
-/* Glow effect for the play-morse-btn when active */
-#play-morse-btn.active {
-    box-shadow: 0 0 20px #f6e05e, 0 0 30px #f6e05e; /* Similar to .tapper.active glow */
-    /* The existing .active:bg-blue-800 from Tailwind will still apply for background color,
-       which is fine. We're just adding the glow. */
-}
-
 /* --- Privacy Policy Page Styles --- */
 /* Default (Light Theme) Styles for Privacy Page */
 body.privacy-page {

--- a/src/index.html
+++ b/src/index.html
@@ -372,6 +372,18 @@
                 </div>
                  <!-- Morse Playback Settings can remain on Learn & Practice or be moved too. For now, keeping them on L&P. -->
                  <!-- If they need to be moved, the settings div from L&P tab would go here. -->
+
+                <!-- Tapper for I/O Tab -->
+                <div class="mt-8 border-t border-gray-600 pt-6">
+                    <h3 class="text-xl font-semibold mb-3 text-center">Practice Tapping</h3>
+                    <div id="ioTabTapperPlaceholder" class="max-w-md mx-auto bg-gray-700 p-4 rounded-lg shadow-lg">
+                        <!-- The shared visual tapper will be inserted here by JavaScript -->
+                    </div>
+                    <div id="ioTapperGameControls" class="flex flex-col space-y-1 md:space-y-2 w-full max-w-xs mx-auto mt-3">
+                        <button id="play-io-tapped-morse-btn" class="w-full bg-purple-500 hover:bg-purple-700 active:bg-purple-800 text-white font-semibold py-1 md:py-2 px-3 md:px-4 rounded-md transition-colors duration-300 ease-in-out focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-purple-500 disabled:opacity-50 disabled:cursor-not-allowed" disabled>Play My Tapped Morse</button>
+                        <button id="clear-io-tapper-input-btn" class="w-full bg-red-500 hover:bg-red-700 active:bg-red-800 text-white font-semibold py-1 md:py-2 px-3 md:px-4 rounded-md transition-colors duration-300 ease-in-out focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-red-500">Clear My Tapping</button>
+                    </div>
+                </div>
             </div>
         </div>
     </div>

--- a/src/index.html
+++ b/src/index.html
@@ -359,8 +359,8 @@
                     <div class="flex flex-col space-y-2">
                         <label for="morse-output" class="block text-sm font-medium">Morse Code Output:</label>
                         <textarea id="morse-output" class="input-output-box w-full focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500" placeholder="Or type Morse here (e.g. .... . .-.. .-.. ---)" readonly></textarea>
-                        <div class="controls mt-2 space-x-2 self-start flex items-center"> <!-- Playback buttons moved here, added flex items-center -->
-                            <button id="play-morse-btn" class="tapper w-20 h-20 text-xs mr-2">Play Morse</button> <!-- Added tapper class, removed conflicting Tailwind classes -->
+                        <div class="controls mt-2 space-x-2 self-start"> <!-- Playback buttons moved here, reverted parent div -->
+                            <button id="play-morse-btn" class="bg-blue-600 hover:bg-blue-700 active:bg-blue-800 text-white font-semibold py-2 px-4 rounded-md transition-colors duration-300 ease-in-out focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500">Play Morse Code</button> <!-- Reverted to original classes -->
                             <button id="stop-morse-btn" class="bg-blue-600 hover:bg-blue-700 active:bg-blue-800 text-white font-semibold py-2 px-4 rounded-md transition-colors duration-300 ease-in-out focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 disabled:opacity-50 disabled:cursor-not-allowed">Stop Sound</button>
                         </div>
                         <div class="flex items-center space-x-2 self-start mt-2"> <!-- Copy/Share buttons remain -->

--- a/src/index.html
+++ b/src/index.html
@@ -359,9 +359,9 @@
                     <div class="flex flex-col space-y-2">
                         <label for="morse-output" class="block text-sm font-medium">Morse Code Output:</label>
                         <textarea id="morse-output" class="input-output-box w-full focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500" placeholder="Or type Morse here (e.g. .... . .-.. .-.. ---)" readonly></textarea>
-                        <div class="controls mt-2 space-x-2 self-start"> <!-- Playback buttons moved here -->
-                            <button id="play-morse-btn" class="bg-blue-600 hover:bg-blue-700 active:bg-blue-800 text-white font-semibold py-2 px-4 rounded-md transition-colors duration-300 ease-in-out focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500">Play Morse Code</button>
-                            <button id="stop-morse-btn" class="bg-blue-600 hover:bg-blue-700 active:bg-blue-800 text-white font-semibold py-2 px-4 rounded-md transition-colors duration-300 ease-in-out focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 disabled:opacity-50 disabled:cursor-not-allowed" disabled>Stop Sound</button>
+                        <div class="controls mt-2 space-x-2 self-start flex items-center"> <!-- Playback buttons moved here, added flex items-center -->
+                            <button id="play-morse-btn" class="tapper w-20 h-20 text-xs mr-2">Play Morse</button> <!-- Added tapper class, removed conflicting Tailwind classes -->
+                            <button id="stop-morse-btn" class="bg-blue-600 hover:bg-blue-700 active:bg-blue-800 text-white font-semibold py-2 px-4 rounded-md transition-colors duration-300 ease-in-out focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 disabled:opacity-50 disabled:cursor-not-allowed">Stop Sound</button>
                         </div>
                         <div class="flex items-center space-x-2 self-start mt-2"> <!-- Copy/Share buttons remain -->
                             <button id="copy-morse-btn" class="bg-blue-600 hover:bg-blue-700 active:bg-blue-800 text-white font-semibold py-2 px-4 rounded-md transition-colors duration-300 ease-in-out focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500">Copy Morse</button>

--- a/src/js/learnPracticeGame.js
+++ b/src/js/learnPracticeGame.js
@@ -306,11 +306,11 @@ document.addEventListener('DOMContentLoaded', () => {
 
             if (morseToPlay) {
                 try {
-                    // console.log("[LearnPracticeGame] Calling playMorseSequence..."); // Log removed
-                    await playMorseSequence(morseToPlay); 
-                    // console.log("[LearnPracticeGame] playMorseSequence finished."); // Log removed
+                    // console.log("[LearnPracticeGame] Calling playMorseSequence for tapper playback..."); // Log removed
+                    await playMorseSequence(morseToPlay, null, null, 'tapper'); // Pass 'tapper' as elementToGlowId
+                    // console.log("[LearnPracticeGame] playMorseSequence for tapper finished."); // Log removed
                 } catch (error) {
-                    console.error("[LearnPracticeGame] Error during playMorseSequence:", error); // Keep this error log
+                    console.error("[LearnPracticeGame] Error during playMorseSequence for tapper:", error); // Keep this error log
                 }
             } else {
                 // console.log("[LearnPracticeGame] Nothing to play (text converted to empty Morse)."); // Log removed

--- a/src/js/learnPracticeGame.js
+++ b/src/js/learnPracticeGame.js
@@ -307,7 +307,7 @@ document.addEventListener('DOMContentLoaded', () => {
             if (morseToPlay) {
                 try {
                     // console.log("[LearnPracticeGame] Calling playMorseSequence for tapper playback..."); // Log removed
-                    await playMorseSequence(morseToPlay, null, null, 'tapper'); // Pass 'tapper' as elementToGlowId
+                    await playMorseSequence(morseToPlay, null, null, 'tapper', 'play-tapped-morse-btn');
                     // console.log("[LearnPracticeGame] playMorseSequence for tapper finished."); // Log removed
                 } catch (error) {
                     console.error("[LearnPracticeGame] Error during playMorseSequence for tapper:", error); // Keep this error log

--- a/src/js/main.js
+++ b/src/js/main.js
@@ -327,6 +327,8 @@ async function playMorseSequence(morse, customDotDur, customFreq) {
     if (isPlaying) return;
     isPlaying = true;
     stopMorseCode = false;
+    // playMorseBtn is already declared in the global scope of main.js
+    // const playMorseBtn = document.getElementById('play-morse-btn');
     if(playMorseBtn) playMorseBtn.disabled = true;
     if(stopMorseBtn) stopMorseBtn.disabled = false;
 
@@ -419,7 +421,9 @@ async function playMorseSequence(morse, customDotDur, customFreq) {
         }
 
         if (durationToPlay > 0) {
+            if(playMorseBtn) playMorseBtn.classList.add('active');
             await playTone(currentFreq, durationToPlay);
+            if(playMorseBtn) playMorseBtn.classList.remove('active');
         }
 
         // Determine if it's the last element of a character or word

--- a/src/js/main.js
+++ b/src/js/main.js
@@ -338,22 +338,28 @@ async function playMorseSequence(morse, customDotDur, customFreq, elementToGlowI
     isPlaying = true;
     stopMorseCode = false;
 
-    const buttonToDisable = document.getElementById('play-tapped-morse-btn'); // Default to tapper's play button
-    const ioTapperPlayButton = document.getElementById('play-io-tapped-morse-btn');
-    let actualButtonToDisable = buttonToDisable;
+    let actualButtonToDisable = null;
+    const learnPracticePlayBtn = document.getElementById('play-tapped-morse-btn');
+    const ioTapperPlayBtn = document.getElementById('play-io-tapped-morse-btn');
+    // playMorseBtn is global, for the main I/O textarea playback
 
-    if (elementToGlowId) { // If an element is supposed to glow, assume its play button triggered this.
-      if (elementToGlowId === 'tapper' && document.getElementById('sharedVisualTapperWrapper').parentNode.id === 'ioTabTapperPlaceholder'){
-        actualButtonToDisable = ioTapperPlayButton;
-      } else if (elementToGlowId === 'tapper' && document.getElementById('sharedVisualTapperWrapper').parentNode.id === 'tapper-placeholder'){
-        actualButtonToDisable = buttonToDisable; // This is the learnPractice one
-      }
-    } else { // If no element to glow, it's the main I/O play button
+    if (elementToGlowId === 'tapper') {
+        const tapperWrapper = document.getElementById('sharedVisualTapperWrapper');
+        const tapperParentId = tapperWrapper ? tapperWrapper.parentNode ? tapperWrapper.parentNode.id : null : null;
+
+        if (tapperParentId === 'ioTabTapperPlaceholder') {
+            actualButtonToDisable = ioTapperPlayBtn;
+        } else if (tapperParentId === 'tapper-placeholder') { // Learn & Practice tab
+            actualButtonToDisable = learnPracticePlayBtn;
+        }
+        // If tapper is on another tab (e.g. Intro, Book Cipher) without a dedicated play button, actualButtonToDisable remains null.
+    } else if (!elementToGlowId) { // This means main playback from I/O tab's textarea
         actualButtonToDisable = playMorseBtn;
     }
+    // In other cases (e.g., elementToGlowId is something else), actualButtonToDisable remains null.
 
-    if(actualButtonToDisable) actualButtonToDisable.disabled = true;
-    if(stopMorseBtn) stopMorseBtn.disabled = false; // Stop button is global for any playback
+    if (actualButtonToDisable) actualButtonToDisable.disabled = true;
+    if (stopMorseBtn) stopMorseBtn.disabled = false; // Stop button is global for any playback
 
     const elementToGlow = elementToGlowId ? document.getElementById(elementToGlowId) : null;
 

--- a/src/js/main.js
+++ b/src/js/main.js
@@ -182,7 +182,7 @@ if(playMorseBtn) playMorseBtn.addEventListener('click', async () => {
     initAudio();
     const morse = morseOutput ? morseOutput.value : "";
     if (morse) {
-        await playMorseSequence(morse); // No elementToGlowId, so no glow from this button
+        await playMorseSequence(morse, null, null, 'tapper', 'playMorseBtn');
     }
 });
 
@@ -333,7 +333,7 @@ function textToMorse(text) {
     return text.toUpperCase().split('').map(char => morseCode[char] || (char === ' ' ? '/' : '')).join(' ');
 }
 
-async function playMorseSequence(morse, customDotDur, customFreq, elementToGlowId) { // Added elementToGlowId
+async function playMorseSequence(morse, customDotDur, customFreq, elementToGlowId, initiatingButtonId) { // Added initiatingButtonId
     if (isPlaying) return;
     isPlaying = true;
     stopMorseCode = false;
@@ -341,22 +341,17 @@ async function playMorseSequence(morse, customDotDur, customFreq, elementToGlowI
     let actualButtonToDisable = null;
     const learnPracticePlayBtn = document.getElementById('play-tapped-morse-btn');
     const ioTapperPlayBtn = document.getElementById('play-io-tapped-morse-btn');
-    // playMorseBtn is global, for the main I/O textarea playback
+    // playMorseBtn is global (for main I/O textarea playback)
 
-    if (elementToGlowId === 'tapper') {
-        const tapperWrapper = document.getElementById('sharedVisualTapperWrapper');
-        const tapperParentId = tapperWrapper ? tapperWrapper.parentNode ? tapperWrapper.parentNode.id : null : null;
-
-        if (tapperParentId === 'ioTabTapperPlaceholder') {
-            actualButtonToDisable = ioTapperPlayBtn;
-        } else if (tapperParentId === 'tapper-placeholder') { // Learn & Practice tab
-            actualButtonToDisable = learnPracticePlayBtn;
-        }
-        // If tapper is on another tab (e.g. Intro, Book Cipher) without a dedicated play button, actualButtonToDisable remains null.
-    } else if (!elementToGlowId) { // This means main playback from I/O tab's textarea
+    if (initiatingButtonId === 'playMorseBtn') {
         actualButtonToDisable = playMorseBtn;
+    } else if (initiatingButtonId === 'play-tapped-morse-btn') {
+        actualButtonToDisable = learnPracticePlayBtn;
+    } else if (initiatingButtonId === 'play-io-tapped-morse-btn') {
+        actualButtonToDisable = ioTapperPlayBtn;
     }
-    // In other cases (e.g., elementToGlowId is something else), actualButtonToDisable remains null.
+    // If initiatingButtonId is something else or null, actualButtonToDisable remains null.
+    // This logic prioritizes the initiatingButtonId for disabling.
 
     if (actualButtonToDisable) actualButtonToDisable.disabled = true;
     if (stopMorseBtn) stopMorseBtn.disabled = false; // Stop button is global for any playback
@@ -780,7 +775,7 @@ document.addEventListener('DOMContentLoaded', () => {
                 // If it's from "decoded" text, it would need conversion.
                 // For now, assume tapperMorseOutput.textContent is playable Morse.
                 initAudio(); // Ensure audio context is ready
-                await playMorseSequence(morseOutputOnTapper.trim(), null, null, 'tapper');
+                await playMorseSequence(morseOutputOnTapper.trim(), null, null, 'tapper', 'play-io-tapped-morse-btn');
             }
         });
     }


### PR DESCRIPTION
- Modified the main 'Play Morse Code' button on the I/O tab to trigger a glow effect on the shared tapper element during audio playback.
- Updated `playMorseSequence` to accept an `initiatingButtonId` parameter to correctly manage the disabled state of the button that triggered the playback (main I/O play, I/O tapper play, or Learn & Practice tapper play).
- Ensured that tapper self-glow for its own play buttons on I/O and Learn & Practice tabs remains functional.
- All play buttons now correctly disable during their respective playback operations and re-enable afterwards.